### PR TITLE
Preinstall common app dependencies

### DIFF
--- a/Dockerfile-deploy
+++ b/Dockerfile-deploy
@@ -6,6 +6,8 @@ MAINTAINER info@codegram.com
 ENV RAILS_ENV=production
 ENV PORT=3000
 
+RUN cd /tmp && decidim test_app && rm -fR test_app
+
 ONBUILD COPY Gemfile Gemfile.lock ./
 ONBUILD RUN bundle install
 ONBUILD COPY . .

--- a/Dockerfile-deploy
+++ b/Dockerfile-deploy
@@ -6,6 +6,10 @@ MAINTAINER info@codegram.com
 ENV RAILS_ENV=production
 ENV PORT=3000
 
+# Build a test app in order to be able to precache dependencies. The
+# app itself is removed afterwards as dependencies will get installed
+# under /usr/local/bundle.
+#
 RUN cd /tmp && \
     decidim decidim_app --skip-bundle && \
     cd decidim_app && \

--- a/Dockerfile-deploy
+++ b/Dockerfile-deploy
@@ -6,7 +6,11 @@ MAINTAINER info@codegram.com
 ENV RAILS_ENV=production
 ENV PORT=3000
 
-RUN cd /tmp && decidim test_app && rm -fR test_app
+RUN cd /tmp && \
+    decidim decidim_app --skip-bundle && \
+    cd decidim_app && \
+    bundle install --without development,test && \
+    rm -fR decidim_app
 
 ONBUILD COPY Gemfile Gemfile.lock ./
 ONBUILD RUN bundle install

--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -30,6 +30,10 @@ RUN wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSI
 
 RUN gem install decidim-dev:$decidim_version
 
+# Build a test app in order to be able to precache dependencies. The
+# app itself is removed afterwards as dependencies will get installed
+# under /usr/local/bundle.
+#
 RUN cd /tmp && \
     decidim decidim_app && \
     rm -fR decidim_app

--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -30,4 +30,8 @@ RUN wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSI
 
 RUN gem install decidim-dev:$decidim_version
 
+RUN cd /tmp && \
+    decidim decidim_app && \
+    rm -fR decidim_app
+
 ENTRYPOINT []


### PR DESCRIPTION
This will preinstall decidim docker's app dependencies in their `deploy` and `dev` variants so you'll save network requests when using them.