### PR TITLE
Don't preinstall dependencies for now

### DIFF
--- a/Dockerfile-deploy
+++ b/Dockerfile-deploy
@@ -6,16 +6,6 @@ MAINTAINER info@codegram.com
 ENV RAILS_ENV=production
 ENV PORT=3000
 
-# Build a test app in order to be able to precache dependencies. The
-# app itself is removed afterwards as dependencies will get installed
-# under /usr/local/bundle.
-#
-RUN cd /tmp && \
-    decidim decidim_app --skip-bundle && \
-    cd decidim_app && \
-    bundle install --without development,test && \
-    rm -fR decidim_app
-
 ONBUILD COPY Gemfile Gemfile.lock ./
 ONBUILD RUN bundle install
 ONBUILD COPY . .

--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -30,12 +30,4 @@ RUN wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSI
 
 RUN gem install decidim-dev:$decidim_version
 
-# Build a test app in order to be able to precache dependencies. The
-# app itself is removed afterwards as dependencies will get installed
-# under /usr/local/bundle.
-#
-RUN cd /tmp && \
-    decidim decidim_app && \
-    rm -fR decidim_app
-
 ENTRYPOINT []


### PR DESCRIPTION
Bundler 1.16.0 is still giving us problems. Now we're hitting bundler/bundler#6154 and bundler/bundler#6162.

Basically, `bundler 1.16.0` generates binstubs with the path to the originating `Gemfile` hardcoded. That means that we end up with a bundler binstub at `/usr/local/bundle/bin/bundle` containing `/tmp/decidim_app/Gemfile` hardcoded, but that folder no longer exists in the image.

This seems to not have propagated yet to decidim's builds, but it's easily reproducible by logging into a built container of the image and running `bundle`. It leads to:

```
[!] There was an error parsing `Gemfile`: No such file or directory @ rb_sysopen - /tmp/decidim_app/Gemfile. Bundler cannot continue
```

You can also see a reproduction in my decidim fork (which had no base image caching, so hits the bug): https://circleci.com/gh/deivid-rodriguez/decidim/527.

Now, we have the following options:

* Remove preinstallation for now.
* Pin to an older image. Now I know a better way to do this now that building and pushing a local image, the one mention in [this comment](https://github.com/docker-library/ruby/issues/171#issuecomment-342710084):

```Dockerfile
FROM ruby@sha256:eed291437be80359321bf66a842d4d542a789e687b38c31bd1659065b2906778
...
```

* Manually downgrade bundler in our base `Dockerfile`. Workaround mentioned [here](https://github.com/bundler/bundler/issues/6162#issue-272343084):

```Dockerfile
RUN gem uninstall --all --executables --force --install-dir /usr/local/lib/ruby/gems/2.4.0 bundler && \
    gem install bundler --version 1.15.4

ENV BUNDLER_VERSION=1.15.4
```

Let me know what you think it's best!