### PR TITLE
Install yarn using native method

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,10 @@ RUN apt-get install -y git imagemagick wget
 RUN curl -sL https://deb.nodesource.com/setup_9.x | bash - \
     && apt-get install -y nodejs=9.2.0-1nodesource1
 
-RUN npm install -g yarn@v1.3.2
+RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
+RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
+
+RUN apt-get update && apt-get install yarn
 
 RUN gem install decidim:$decidim_version
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 FROM ruby:2.4.2
 MAINTAINER info@codegram.com
+
 ARG decidim_version
 
 ENV LANG C.UTF-8


### PR DESCRIPTION
Install yarn using `dpkg` instead of `npm`.