### PR TITLE
Use build version to allow skipping cache

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,11 @@
 FROM ruby:2.4.2
 MAINTAINER info@codegram.com
 
+# Increment this variable to force a rebuild from this step on.
+# This is useful when we want to rebuild the image from scratch to
+# prevent using cache.
+RUN echo FORCE_REBUILD_VERSION=1
+
 ARG decidim_version
 
 ENV LANG C.UTF-8

--- a/circle.yml
+++ b/circle.yml
@@ -25,7 +25,7 @@ jobs:
           shell: /bin/bash
           command: |
             set -e
-            docker build -f Dockerfile \
+            docker build -f Dockerfile --pull \
                         --build-arg decidim_version=$DECIDIM_VERSION \
                         -t decidim:${CIRCLE_SHA1} \
                         --cache-from=decidim/decidim:latest .


### PR DESCRIPTION
This introduces a `FORCE_REBUILD_VERSION` dummy echo to force rebuilding from that step on when we might need it.

It also ensures the docker image is build using `--pull` so we get the latest base ruby image in each rebuild.