### PR TITLE
Add test image

### DIFF
--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -1,5 +1,12 @@
 ARG base_image=decidim/decidim:latest-test
 
+FROM $base_image
+LABEL maintainer="info@codegram.com"
+
+ARG decidim_version
+
+ARG base_image=decidim/decidim:latest-test
+
 RUN apt-get install -y sudo && \
     apt-get clean
 

--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -1,33 +1,4 @@
-ARG base_image=decidim/decidim:latest
-
-FROM $base_image
-LABEL maintainer="info@codegram.com"
-
-ARG decidim_version
-
-RUN apt-get update \
-  && apt-get install -y unzip
-
-ENV DOCKERIZE_VERSION=v0.6.0
-ENV CHROMEDRIVER_RELEASE=2.35
-
-RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -
-RUN sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list'
-RUN apt-get update && apt-get install -y google-chrome-stable
-
-RUN CHROMEDRIVER_URL="http://chromedriver.storage.googleapis.com/$CHROMEDRIVER_RELEASE/chromedriver_linux64.zip" \
-    && curl --silent --show-error --location --fail --retry 3 --output /tmp/chromedriver_linux64.zip $CHROMEDRIVER_URL \
-    && unzip /tmp/chromedriver_linux64.zip chromedriver -d /usr/local/bin \
-    && rm /tmp/chromedriver_linux64.zip \
-    && chromedriver --version
-
-RUN apt-get update && apt-get install -y wget
-
-RUN wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
-    && tar -C /usr/local/bin -xzvf dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
-    && rm dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz
-
-RUN gem install decidim-dev:$decidim_version
+ARG base_image=decidim/decidim:latest-test
 
 RUN apt-get install -y sudo && \
     apt-get clean

--- a/Dockerfile-test
+++ b/Dockerfile-test
@@ -1,0 +1,30 @@
+ARG base_image=decidim/decidim:latest
+
+FROM $base_image
+LABEL maintainer="info@codegram.com"
+
+ARG decidim_version
+
+RUN apt-get update \
+  && apt-get install -y unzip
+
+ENV DOCKERIZE_VERSION=v0.6.0
+ENV CHROMEDRIVER_RELEASE=2.35
+
+RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -
+RUN sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list'
+RUN apt-get update && apt-get install -y google-chrome-stable
+
+RUN CHROMEDRIVER_URL="http://chromedriver.storage.googleapis.com/$CHROMEDRIVER_RELEASE/chromedriver_linux64.zip" \
+    && curl --silent --show-error --location --fail --retry 3 --output /tmp/chromedriver_linux64.zip $CHROMEDRIVER_URL \
+    && unzip /tmp/chromedriver_linux64.zip chromedriver -d /usr/local/bin \
+    && rm /tmp/chromedriver_linux64.zip \
+    && chromedriver --version
+
+RUN apt-get update && apt-get install -y wget
+
+RUN wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
+    && tar -C /usr/local/bin -xzvf dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
+    && rm dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz
+
+RUN gem install decidim-dev:$decidim_version

--- a/circle.yml
+++ b/circle.yml
@@ -18,6 +18,7 @@ jobs:
           name: Pull images
           command: |
             docker pull decidim/decidim:latest || true
+            docker pull decidim/decidim:latest-test || true
             docker pull decidim/decidim:latest-dev || true
             docker pull decidim/decidim:latest-deploy || true
       - run:
@@ -30,8 +31,14 @@ jobs:
                         -t decidim:${CIRCLE_SHA1} \
                         --cache-from=decidim/decidim:latest .
 
-            docker build -f Dockerfile-dev \
+            docker build -f Dockerfile-test \
                         --build-arg base_image=decidim:${CIRCLE_SHA1} \
+                        --build-arg decidim_version=$DECIDIM_VERSION \
+                        -t decidim:${CIRCLE_SHA1}-test \
+                        --cache-from=decidim/decidim:latest-test .
+
+            docker build -f Dockerfile-dev \
+                        --build-arg base_image=decidim:${CIRCLE_SHA1}-test \
                         --build-arg decidim_version=$DECIDIM_VERSION \
                         -t decidim:${CIRCLE_SHA1}-dev \
                         --cache-from=decidim/decidim:latest-dev .
@@ -50,11 +57,13 @@ jobs:
               docker login -u $DOCKER_USER -p $DOCKER_PASS
 
               docker tag decidim:${CIRCLE_SHA1}-deploy decidim/decidim:latest-deploy
+              docker tag decidim:${CIRCLE_SHA1}-test decidim/decidim:latest-test
               docker tag decidim:${CIRCLE_SHA1}-dev decidim/decidim:latest-dev
               docker tag decidim:${CIRCLE_SHA1} decidim/decidim:latest
 
               docker push decidim/decidim:latest-deploy
               docker push decidim/decidim:latest-dev
+              docker push decidim/decidim:latest-test
               docker push decidim/decidim:latest
             fi
 
@@ -62,10 +71,12 @@ jobs:
               docker login -u $DOCKER_USER -p $DOCKER_PASS
 
               docker tag decidim:${CIRCLE_SHA1}-deploy decidim/decidim:${CIRCLE_BRANCH}-deploy
+              docker tag decidim:${CIRCLE_SHA1}-test decidim/decidim:${CIRCLE_BRANCH}-test
               docker tag decidim:${CIRCLE_SHA1}-dev decidim/decidim:${CIRCLE_BRANCH}-dev
               docker tag decidim:${CIRCLE_SHA1} decidim/decidim:${CIRCLE_BRANCH}
 
               docker push decidim/decidim:${CIRCLE_BRANCH}-deploy
               docker push decidim/decidim:${CIRCLE_BRANCH}-dev
+              docker push decidim/decidim:${CIRCLE_BRANCH}-test
               docker push decidim/decidim:${CIRCLE_BRANCH}
             fi


### PR DESCRIPTION
Adds a test image meant to be used on test-only environments like a CI server. It lacks other facilities usually useful when mounting local folders and expecting code reload & such.