### PR TITLE
Remove bad fix

### DIFF
--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -6,7 +6,7 @@ LABEL maintainer="info@codegram.com"
 RUN apt-get install -y sudo \
   && apt-get clean
 
-RUN adduser --home /code --shell /bin/bash --disabled-password --gecos "" decidim \
+RUN adduser --shell /bin/bash --disabled-password --gecos "" decidim \
   && adduser decidim sudo \
   && echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 

--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -13,8 +13,6 @@ RUN adduser --home /code --shell /bin/bash --disabled-password --gecos "" decidi
 RUN echo 'Defaults secure_path="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bundle/bin"' > /etc/sudoers.d/secure_path
 RUN chmod 0440 /etc/sudoers.d/secure_path
 
-RUN mkdir /gems && chown decidim:decidim /gems
-
 COPY scripts/entrypoint.sh /usr/local/bin/entrypoint.sh
 
 ENTRYPOINT []

--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -10,7 +10,7 @@ RUN adduser --home /code --shell /bin/bash --disabled-password --gecos "" decidi
   && adduser decidim sudo \
   && echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 
-RUN echo 'Defaults secure_path="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/gems/bin"' > /etc/sudoers.d/secure_path
+RUN echo 'Defaults secure_path="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bundle/bin"' > /etc/sudoers.d/secure_path
 RUN chmod 0440 /etc/sudoers.d/secure_path
 
 RUN mkdir /gems && chown decidim:decidim /gems

--- a/README.md
+++ b/README.md
@@ -4,4 +4,4 @@
 
 The development image is intended to be in conjunction with docker-compose. This image includes an script that makes feasible to keep ownership of the files created inside the container for for the user used ouside it.
 
-It is convenient, but not absolutelly mandatory that you create a volume for the /usr/local/bundle folder.
+It is convenient, but not absolutely mandatory that you create a volume for the /usr/local/bundle folder.

--- a/README.md
+++ b/README.md
@@ -4,4 +4,4 @@
 
 The development image is intended to be in conjunction with docker-compose. This image includes an script that makes feasible to keep ownership of the files created inside the container for for the user used ouside it.
 
-It is convenient, but not absolutelly mandatory that you create a volume for the /gems folder.
+It is convenient, but not absolutelly mandatory that you create a volume for the /usr/local/bundle folder.

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -1,10 +1,5 @@
 #!/bin/sh -x
 
-# https://github.com/docker-library/ruby/issues/66
-export BUNDLE_PATH=/gems
-export BUNDLE_BIN=/gems/bin
-export BUNDLE_APP_CONFIG=/gems/config
-
 USER_UID=$(stat -c %u /code/Gemfile)
 USER_GID=$(stat -c %g /code/Gemfile)
 


### PR DESCRIPTION
I don't think this was fixing anything but actually breaking things:

* This is just changing docker image defaults to a different folder, and
it's actually doing incorrectly because it's leaving `GEM_HOME` with the
default value, so when installing gems via `gem install <gem>`, they get
installed to a wrong location (this affects generator specs in decidim).
See
https://github.com/docker-library/ruby/blob/master/Dockerfile-debian.template#L69-L74.

* Also, the folder name is confusing, since gems get actually installed
to a "gems" subfolder inside this "gems" folder.

* Finally, I don't see how the linked issue relates to this.