### PR TITLE
Fix base image for dev image

### DIFF
--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -3,8 +3,6 @@ ARG base_image=decidim/decidim:latest-test
 FROM $base_image
 LABEL maintainer="info@codegram.com"
 
-ARG decidim_version
-
 RUN apt-get install -y sudo \
   && apt-get clean
 

--- a/scripts/build_images.sh
+++ b/scripts/build_images.sh
@@ -17,7 +17,7 @@ docker build -f Dockerfile-test \
             --cache-from=decidim/decidim:latest-test .
 
 docker build -f Dockerfile-dev \
-            --build-arg "base_image=decidim/decidim:$sha1" \
+            --build-arg "base_image=decidim/decidim:$sha1-test" \
             -t "decidim/decidim:$sha1-dev" \
             --cache-from=decidim/decidim:latest-dev .
 

--- a/scripts/build_images.sh
+++ b/scripts/build_images.sh
@@ -18,7 +18,6 @@ docker build -f Dockerfile-test \
 
 docker build -f Dockerfile-dev \
             --build-arg "base_image=decidim/decidim:$sha1" \
-            --build-arg "decidim_version=$version" \
             -t "decidim/decidim:$sha1-dev" \
             --cache-from=decidim/decidim:latest-dev .
 


### PR DESCRIPTION
This fixes a bug I introduced in #19 where I incorrectly specified the base image for the `Dockerfile-dev` image. It also removes an unsued argument.