### PR TITLE
Remove unnecessary workaround

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,6 @@ RUN curl -sL https://deb.nodesource.com/setup_9.x | bash - \
 
 RUN npm install -g npm
 
-RUN gem update --system
 RUN gem install decidim:$decidim_version
 
 ENTRYPOINT ["decidim"]

--- a/Dockerfile-test
+++ b/Dockerfile-test
@@ -5,19 +5,6 @@ LABEL maintainer="info@codegram.com"
 
 ARG decidim_version
 
-#
-# This is needed in order to pick up
-# https://github.com/rubygems/rubygems/pull/2196, because otherwise our
-# generator tests won't play nice with rubygems. To be removed once rubygems
-# 2.7.7 is released and the image starts using it.
-#
-RUN git clone https://github.com/rubygems/rubygems /tmp/rubygems \
-  && cd /tmp/rubygems \
-  && git checkout e093fb7d594f97edaa6289547a90537871ca5f98 \
-  && git submodule update --init \
-  && ruby setup.rb \
-  && rm -rf /tmp/rubygems
-
 RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
   && sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list' \
   && apt-get update \

--- a/scripts/build_images.sh
+++ b/scripts/build_images.sh
@@ -4,24 +4,29 @@ set -e
 
 sha1=${CIRCLE_SHA1:-latest}
 version=${DECIDIM_VERSION:-0.10.0}
+extra_args=("$@")
 
 docker build -f Dockerfile \
             --build-arg "decidim_version=$version" \
             -t "decidim/decidim:$sha1" \
-            --cache-from=decidim/decidim:latest .
+            --cache-from=decidim/decidim:latest \
+            "${extra_args[@]}" .
 
 docker build -f Dockerfile-test \
             --build-arg "base_image=decidim/decidim:$sha1" \
             --build-arg "decidim_version=$version" \
             -t "decidim/decidim:$sha1-test" \
-            --cache-from=decidim/decidim:latest-test .
+            --cache-from=decidim/decidim:latest-test \
+            "${extra_args[@]}" .
 
 docker build -f Dockerfile-dev \
             --build-arg "base_image=decidim/decidim:$sha1-test" \
             -t "decidim/decidim:$sha1-dev" \
-            --cache-from=decidim/decidim:latest-dev .
+            --cache-from=decidim/decidim:latest-dev \
+            "${extra_args[@]}" .
 
 docker build -f Dockerfile-deploy \
             --build-arg "base_image=decidim/decidim:$sha1" \
             -t "decidim/decidim:$sha1-deploy" \
-            --cache-from=decidim/decidim:latest-deploy .
+            --cache-from=decidim/decidim:latest-deploy \
+            "${extra_args[@]}" .


### PR DESCRIPTION
Rubygems 2.7.7 has been released so we no longer need to patch it.

This includes a tweak I added to the build scripts to test building against the new official images.