### PR TITLE
apt-get clean after package installation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,10 +8,12 @@ ENV LC_ALL C.UTF-8
 
 WORKDIR /code
 
-RUN apt-get install -y git imagemagick wget
+RUN apt-get install -y git imagemagick wget \
+  && apt-get clean
 
 RUN curl -sL https://deb.nodesource.com/setup_9.x | bash - \
-  && apt-get install -y nodejs
+  && apt-get install -y nodejs \
+  && apt-get clean
 
 RUN npm install -g npm
 

--- a/Dockerfile-test
+++ b/Dockerfile-test
@@ -21,7 +21,8 @@ RUN git clone https://github.com/rubygems/rubygems /tmp/rubygems \
 RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
   && sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list' \
   && apt-get update \
-  && apt-get install -y google-chrome-stable
+  && apt-get install -y google-chrome-stable \
+  && apt-get clean
 
 RUN CHROMEDRIVER_RELEASE=2.38 \
   && CHROMEDRIVER_URL="http://chromedriver.storage.googleapis.com/$CHROMEDRIVER_RELEASE/chromedriver_linux64.zip" \


### PR DESCRIPTION
Run `apt-get clean` after package installation. I guess this helps reducing image size. This was done is some places but not everywhere.