### PR TITLE
Bump base decidim & push released tags when merging to master

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -15,9 +15,6 @@ jobs:
       - setup_remote_docker:
           version: 17.11.0-ce
       - run:
-          name: Pull images
-          command: scripts/pull_images.sh
-      - run:
           name: Build images
           command: scripts/build_images.sh
       - run:

--- a/circle.yml
+++ b/circle.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     working_directory: /app
     environment:
-      - DECIDIM_VERSION=0.12.0
+      - DECIDIM_VERSION=0.13.1
     docker:
       - image: docker:17.11.0-ce-git
     steps:

--- a/scripts/build_images.sh
+++ b/scripts/build_images.sh
@@ -10,6 +10,7 @@ extra_args=("$@")
 docker build --file Dockerfile \
              --build-arg "decidim_version=$version" \
              --tag "decidim/decidim:$sha1" \
+             --tag "decidim/decidim:$version" \
              --tag "decidim/decidim:latest" \
              "${extra_args[@]}" .
 
@@ -17,17 +18,20 @@ docker build --file Dockerfile-test \
              --build-arg "base_image=decidim/decidim:$sha1" \
              --build-arg "decidim_version=$version" \
              --tag "decidim/decidim:$sha1-test" \
+             --tag "decidim/decidim:$version-test" \
              --tag "decidim/decidim:latest-test" \
              "${extra_args[@]}" .
 
 docker build --file Dockerfile-dev \
              --build-arg "base_image=decidim/decidim:$sha1-test" \
              --tag "decidim/decidim:$sha1-dev" \
+             --tag "decidim/decidim:$version-dev" \
              --tag "decidim/decidim:latest-dev" \
              "${extra_args[@]}" .
 
 docker build --file Dockerfile-deploy \
              --build-arg "base_image=decidim/decidim:$sha1" \
              --tag "decidim/decidim:$sha1-deploy" \
+             --tag "decidim/decidim:$version-deploy" \
              --tag "decidim/decidim:latest-deploy" \
              "${extra_args[@]}" .

--- a/scripts/build_images.sh
+++ b/scripts/build_images.sh
@@ -10,20 +10,24 @@ extra_args=("$@")
 docker build --file Dockerfile \
              --build-arg "decidim_version=$version" \
              --tag "decidim/decidim:$sha1" \
+             --tag "decidim/decidim:latest" \
              "${extra_args[@]}" .
 
 docker build --file Dockerfile-test \
              --build-arg "base_image=decidim/decidim:$sha1" \
              --build-arg "decidim_version=$version" \
              --tag "decidim/decidim:$sha1-test" \
+             --tag "decidim/decidim:latest-test" \
              "${extra_args[@]}" .
 
 docker build --file Dockerfile-dev \
              --build-arg "base_image=decidim/decidim:$sha1-test" \
              --tag "decidim/decidim:$sha1-dev" \
+             --tag "decidim/decidim:latest-dev" \
              "${extra_args[@]}" .
 
 docker build --file Dockerfile-deploy \
              --build-arg "base_image=decidim/decidim:$sha1" \
              --tag "decidim/decidim:$sha1-deploy" \
+             --tag "decidim/decidim:latest-deploy" \
              "${extra_args[@]}" .

--- a/scripts/build_images.sh
+++ b/scripts/build_images.sh
@@ -8,22 +8,22 @@ version=${DECIDIM_VERSION:-$latest_version}
 extra_args=("$@")
 
 docker build --file Dockerfile \
-            --build-arg "decidim_version=$version" \
-            --tag "decidim/decidim:$sha1" \
-            "${extra_args[@]}" .
+             --build-arg "decidim_version=$version" \
+             --tag "decidim/decidim:$sha1" \
+             "${extra_args[@]}" .
 
 docker build --file Dockerfile-test \
-            --build-arg "base_image=decidim/decidim:$sha1" \
-            --build-arg "decidim_version=$version" \
-            --tag "decidim/decidim:$sha1-test" \
-            "${extra_args[@]}" .
+             --build-arg "base_image=decidim/decidim:$sha1" \
+             --build-arg "decidim_version=$version" \
+             --tag "decidim/decidim:$sha1-test" \
+             "${extra_args[@]}" .
 
 docker build --file Dockerfile-dev \
-            --build-arg "base_image=decidim/decidim:$sha1-test" \
-            --tag "decidim/decidim:$sha1-dev" \
-            "${extra_args[@]}" .
+             --build-arg "base_image=decidim/decidim:$sha1-test" \
+             --tag "decidim/decidim:$sha1-dev" \
+             "${extra_args[@]}" .
 
 docker build --file Dockerfile-deploy \
-            --build-arg "base_image=decidim/decidim:$sha1" \
-            --tag "decidim/decidim:$sha1-deploy" \
-            "${extra_args[@]}" .
+             --build-arg "base_image=decidim/decidim:$sha1" \
+             --tag "decidim/decidim:$sha1-deploy" \
+             "${extra_args[@]}" .

--- a/scripts/build_images.sh
+++ b/scripts/build_images.sh
@@ -7,23 +7,23 @@ latest_version=$(curl https://rubygems.org/api/v1/versions/decidim/latest.json |
 version=${DECIDIM_VERSION:-$latest_version}
 extra_args=("$@")
 
-docker build -f Dockerfile \
+docker build --file Dockerfile \
             --build-arg "decidim_version=$version" \
-            -t "decidim/decidim:$sha1" \
+            --tag "decidim/decidim:$sha1" \
             "${extra_args[@]}" .
 
-docker build -f Dockerfile-test \
+docker build --file Dockerfile-test \
             --build-arg "base_image=decidim/decidim:$sha1" \
             --build-arg "decidim_version=$version" \
-            -t "decidim/decidim:$sha1-test" \
+            --tag "decidim/decidim:$sha1-test" \
             "${extra_args[@]}" .
 
-docker build -f Dockerfile-dev \
+docker build --file Dockerfile-dev \
             --build-arg "base_image=decidim/decidim:$sha1-test" \
-            -t "decidim/decidim:$sha1-dev" \
+            --tag "decidim/decidim:$sha1-dev" \
             "${extra_args[@]}" .
 
-docker build -f Dockerfile-deploy \
+docker build --file Dockerfile-deploy \
             --build-arg "base_image=decidim/decidim:$sha1" \
-            -t "decidim/decidim:$sha1-deploy" \
+            --tag "decidim/decidim:$sha1-deploy" \
             "${extra_args[@]}" .

--- a/scripts/pull_images.sh
+++ b/scripts/pull_images.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-
-docker pull decidim/decidim:latest || true
-docker pull decidim/decidim:latest-test || true
-docker pull decidim/decidim:latest-dev || true
-docker pull decidim/decidim:latest-deploy || true

--- a/scripts/push_images.sh
+++ b/scripts/push_images.sh
@@ -2,16 +2,13 @@
 
 set -e
 
-latest_version=$(curl https://rubygems.org/api/v1/versions/decidim/latest.json | grep -o "[0-9][0-9]*.[0-9][0-9]*.[0-9][0-9]*")
-version=${DECIDIM_VERSION:-$latest_version}
-
 if [[ "${CIRCLE_BRANCH}" == "master" ]]; then
   docker login -u "$DOCKER_USER" -p "$DOCKER_PASS"
 
-  docker push "decidim/decidim:$version-deploy"
-  docker push "decidim/decidim:$version-dev"
-  docker push "decidim/decidim:$version-test"
-  docker push "decidim/decidim:$version"
+  docker push "decidim/decidim:$DECIDIM_VERSION-deploy"
+  docker push "decidim/decidim:$DECIDIM_VERSION-dev"
+  docker push "decidim/decidim:$DECIDIM_VERSION-test"
+  docker push "decidim/decidim:$DECIDIM_VERSION"
 
   docker push decidim/decidim:latest-deploy
   docker push decidim/decidim:latest-dev
@@ -22,8 +19,8 @@ fi
 if [[ "${CIRCLE_BRANCH}" =~ ^[0-9\.]+$ ]]; then
   docker login -u "$DOCKER_USER" -p "$DOCKER_PASS"
 
-  docker push "decidim/decidim:$version-deploy"
-  docker push "decidim/decidim:$version-dev"
-  docker push "decidim/decidim:$version-test"
-  docker push "decidim/decidim:$version"
+  docker push "decidim/decidim:$DECIDIM_VERSION-deploy"
+  docker push "decidim/decidim:$DECIDIM_VERSION-dev"
+  docker push "decidim/decidim:$DECIDIM_VERSION-test"
+  docker push "decidim/decidim:$DECIDIM_VERSION"
 fi

--- a/scripts/push_images.sh
+++ b/scripts/push_images.sh
@@ -2,8 +2,16 @@
 
 set -e
 
+latest_version=$(curl https://rubygems.org/api/v1/versions/decidim/latest.json | grep -o "[0-9][0-9]*.[0-9][0-9]*.[0-9][0-9]*")
+version=${DECIDIM_VERSION:-$latest_version}
+
 if [[ "${CIRCLE_BRANCH}" == "master" ]]; then
   docker login -u "$DOCKER_USER" -p "$DOCKER_PASS"
+
+  docker push "decidim/decidim:$version-deploy"
+  docker push "decidim/decidim:$version-dev"
+  docker push "decidim/decidim:$version-test"
+  docker push "decidim/decidim:$version"
 
   docker push decidim/decidim:latest-deploy
   docker push decidim/decidim:latest-dev
@@ -14,8 +22,8 @@ fi
 if [[ "${CIRCLE_BRANCH}" =~ ^[0-9\.]+$ ]]; then
   docker login -u "$DOCKER_USER" -p "$DOCKER_PASS"
 
-  docker push "decidim/decidim:${CIRCLE_BRANCH}-deploy"
-  docker push "decidim/decidim:${CIRCLE_BRANCH}-dev"
-  docker push "decidim/decidim:${CIRCLE_BRANCH}-test"
-  docker push "decidim/decidim:${CIRCLE_BRANCH}"
+  docker push "decidim/decidim:$version-deploy"
+  docker push "decidim/decidim:$version-dev"
+  docker push "decidim/decidim:$version-test"
+  docker push "decidim/decidim:$version"
 fi

--- a/scripts/push_images.sh
+++ b/scripts/push_images.sh
@@ -5,11 +5,6 @@ set -e
 if [[ "${CIRCLE_BRANCH}" == "master" ]]; then
   docker login -u "$DOCKER_USER" -p "$DOCKER_PASS"
 
-  docker tag "decidim/decidim:${CIRCLE_SHA1}-deploy" decidim/decidim:latest-deploy
-  docker tag "decidim/decidim:${CIRCLE_SHA1}-test" decidim/decidim:latest-test
-  docker tag "decidim/decidim:${CIRCLE_SHA1}-dev" decidim/decidim:latest-dev
-  docker tag "decidim/decidim:${CIRCLE_SHA1}" decidim/decidim:latest
-
   docker push decidim/decidim:latest-deploy
   docker push decidim/decidim:latest-dev
   docker push decidim/decidim:latest-test
@@ -18,11 +13,6 @@ fi
 
 if [[ "${CIRCLE_BRANCH}" =~ ^[0-9\.]+$ ]]; then
   docker login -u "$DOCKER_USER" -p "$DOCKER_PASS"
-
-  docker tag "decidim/decidim:${CIRCLE_SHA1}-deploy" "decidim/decidim:${CIRCLE_BRANCH}-deploy"
-  docker tag "decidim/decidim:${CIRCLE_SHA1}-test" "decidim/decidim:${CIRCLE_BRANCH}-test"
-  docker tag "decidim/decidim:${CIRCLE_SHA1}-dev" "decidim/decidim:${CIRCLE_BRANCH}-dev"
-  docker tag "decidim/decidim:${CIRCLE_SHA1}" "decidim/decidim:${CIRCLE_BRANCH}"
 
   docker push "decidim/decidim:${CIRCLE_BRANCH}-deploy"
   docker push "decidim/decidim:${CIRCLE_BRANCH}-dev"


### PR DESCRIPTION
Hi @josepjaume!

I noticed that new decidim applications are generated with a `Dockerfile` like this:
 
```dockerfile
FROM decidim/decidim:0.13.1
```

However, this tag does not exist. As a matter of fact, [no tags](http://dockerhub.com/r/decidim/decidim) like that one have been pushed since decidim 0.10.

By reading the scripts, I see that you're supposed to push to a branch with the same name as the release so that these tags get uploaded to dockerhub. It does not seem a priori a very handy workflow since you need to remember to create a new branch for each release.

What do you think about doing this when merging to master? Whatever tag was used to build the images, we'll push to latest and to that tag (and will overwrite the image if the tag was pushed before, which makes sense to me, I think).

Thoughts?