### PR TITLE
Lock npm version again

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN curl -sL https://deb.nodesource.com/setup_10.x | bash - \
   && apt-get install -y nodejs \
   && apt-get clean
 
-RUN npm install -g npm
+RUN npm install -g npm@6.3.0
 
 RUN gem install decidim:$decidim_version
 


### PR DESCRIPTION
Package managers are quite fragile to regressions and behavior changes
between versions. So I think it's better to lock images to a version we
know it's working fine.