### PR TITLE
Bump Bundler version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,7 @@ RUN curl -sL https://deb.nodesource.com/setup_10.x | bash - \
 
 RUN npm install -g npm@6.3.0
 
-RUN gem install decidim:$decidim_version
+RUN gem install bundler \
+  && gem install decidim:$decidim_version
 
 ENTRYPOINT ["decidim"]


### PR DESCRIPTION
After update to Decidim v0.22.0 the instructions here stopped working:

```bash
docker pull decidim/decidim:0.22.0
APP_NAME=HelloWorld
docker run -it -v "$(pwd):/code" decidim/decidim ${APP_NAME}
```

This gives an error regarding Bundler version:

> You must use Bundler 2 or greater with this lockfile.

This is because Docker Ruby:2.6.6 image comes with Bundler v1.17.2:

> $ docker run --rm -it ruby:2.6.6 bash
> root@874350c34b10:/# bundle --version
> Bundler version 1.17.2

So we need to update manually Bundler. This could be reverted in Ruby 2.7.1:

> $ docker run --rm -it ruby:2.7.1 bash
> root@c095b9cff2bc:/# bundle --version
> Bundler version 2.1.4
