### PR TITLE
Syncrhonize chrome and chrome-driver versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN curl -sL https://deb.nodesource.com/setup_10.x | bash - \
 
 RUN npm install -g npm@6.3.0
 
-RUN gem install bundler \
+RUN gem install bundler --version '>= 2.1.4' \
   && gem install decidim:$decidim_version
 
 ENTRYPOINT ["decidim"]

--- a/Dockerfile-test
+++ b/Dockerfile-test
@@ -11,7 +11,7 @@ RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key
   && apt-get install -y google-chrome-stable \
   && apt-get clean
 
-RUN CHROMEDRIVER_RELEASE=78.0.3904.11 \
+RUN CHROMEDRIVER_RELEASE=85.0.4183.87 \
   && CHROMEDRIVER_URL="http://chromedriver.storage.googleapis.com/$CHROMEDRIVER_RELEASE/chromedriver_linux64.zip" \
   && apt-get install unzip \
   && curl --silent --show-error --location --fail --retry 3 --output /tmp/chromedriver_linux64.zip $CHROMEDRIVER_URL \


### PR DESCRIPTION
Chrome and chrome driver versions have diverged.
This PR synchronizes both in the `Dockerfile-test`.