### PR TITLE
Add remainder images to flow

### DIFF
--- a/.github/workflows/on_push.yml
+++ b/.github/workflows/on_push.yml
@@ -7,14 +7,19 @@ on:
     - master
     paths:
     - 'Dockerfile'
+    - 'Dockerfile-test'
+    - 'Dockerfile-dev'
+    - 'Dockerfile-deploy'
     - '.github/workflows/on_push.yml'
 
 jobs:
   build-publish:
-    name: Build & Publish Docker Image
+    name: Build & Publish Docker Images
     runs-on: ubuntu-latest
     env:
       GENERATOR_IMAGE_NAME: ghcr.io/${{ github.actor }}/decidim-generator
+      TEST_IMAGE_NAME: ghcr.io/${{ github.actor }}/decidim-test
+      DEV_IMAGE_NAME: ghcr.io/${{ github.actor }}/decidim-dev
       APP_IMAGE_NAME: ghcr.io/${{ github.actor }}/decidim
       TAG: ${{ github.sha }}
 
@@ -61,6 +66,46 @@ jobs:
     - run: |
         docker push $GENERATOR_IMAGE_NAME
 
+    - name: Build decidim-test Image
+      env:
+        RUBY_VERSION: ${{ steps.ruby-version.outputs.version }}
+        DECIDIM_VERSION: ${{ steps.decidim-version.outputs.version }}
+      run: |
+        docker build \
+        --file Dockerfile-test \
+        -t $TEST_IMAGE_NAME:$TAG .
+        docker tag $TEST_IMAGE_NAME:$TAG $TEST_IMAGE_NAME:latest
+        docker tag $TEST_IMAGE_NAME:$TAG $TEST_IMAGE_NAME:$DECIDIM_VERSION
+
+    - name: Publish decidim-test Image to Github Container Registry
+      uses: azure/docker-login@v1
+      with:
+        login-server: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.PAT_TOKEN }}
+    - run: |
+        docker push $TEST_IMAGE_NAME
+
+    - name: Build decidim-dev Image
+      env:
+        RUBY_VERSION: ${{ steps.ruby-version.outputs.version }}
+        DECIDIM_VERSION: ${{ steps.decidim-version.outputs.version }}
+      run: |
+        docker build \
+        --file Dockerfile-dev \
+        -t $DEV_IMAGE_NAME:$TAG .
+        docker tag $DEV_IMAGE_NAME:$TAG $DEV_IMAGE_NAME:latest
+        docker tag $DEV_IMAGE_NAME:$TAG $DEV_IMAGE_NAME:$DECIDIM_VERSION
+
+    - name: Publish decidim-dev Image to Github Container Registry
+      uses: azure/docker-login@v1
+      with:
+        login-server: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.PAT_TOKEN }}
+    - run: |
+        docker push $DEV_IMAGE_NAME
+
     - name: Build decidim (app) Image
       env:
         RUBY_VERSION: ${{ steps.ruby-version.outputs.version }}
@@ -68,12 +113,11 @@ jobs:
       run: |
         docker build \
         --file Dockerfile-deploy \
-        --build-arg base_image=$GENERATOR_IMAGE_NAME \
         -t $APP_IMAGE_NAME:$TAG .
         docker tag $APP_IMAGE_NAME:$TAG $APP_IMAGE_NAME:latest
         docker tag $APP_IMAGE_NAME:$TAG $APP_IMAGE_NAME:$DECIDIM_VERSION
 
-    - name: Publish Image to Github Container Registry
+    - name: Publish decidim Image to Github Container Registry
       uses: azure/docker-login@v1
       with:
         login-server: ghcr.io

--- a/.github/workflows/on_push.yml
+++ b/.github/workflows/on_push.yml
@@ -61,8 +61,8 @@ jobs:
       uses: azure/docker-login@v1
       with:
         login-server: ghcr.io
-        username: ${{ github.actor }}
-        password: ${{ secrets.PAT_TOKEN }}
+        username: decidim-bot
+        password: ${{ secrets.CONTAINER_REGISTRY_PAT }}
     - run: |
         docker push $GENERATOR_IMAGE_NAME
 
@@ -81,8 +81,8 @@ jobs:
       uses: azure/docker-login@v1
       with:
         login-server: ghcr.io
-        username: ${{ github.actor }}
-        password: ${{ secrets.PAT_TOKEN }}
+        username: decidim-bot
+        password: ${{ secrets.CONTAINER_REGISTRY_PAT }}
     - run: |
         docker push $TEST_IMAGE_NAME
 
@@ -101,8 +101,8 @@ jobs:
       uses: azure/docker-login@v1
       with:
         login-server: ghcr.io
-        username: ${{ github.actor }}
-        password: ${{ secrets.PAT_TOKEN }}
+        username: decidim-bot
+        password: ${{ secrets.CONTAINER_REGISTRY_PAT }}
     - run: |
         docker push $DEV_IMAGE_NAME
 
@@ -121,7 +121,7 @@ jobs:
       uses: azure/docker-login@v1
       with:
         login-server: ghcr.io
-        username: ${{ github.actor }}
-        password: ${{ secrets.PAT_TOKEN }}
+        username: decidim-bot
+        password: ${{ secrets.CONTAINER_REGISTRY_PAT }}
     - run: |
         docker push $APP_IMAGE_NAME

--- a/.github/workflows/on_push.yml
+++ b/.github/workflows/on_push.yml
@@ -17,10 +17,10 @@ jobs:
     name: Build & Publish Docker Images
     runs-on: ubuntu-latest
     env:
-      GENERATOR_IMAGE_NAME: ghcr.io/${{ github.actor }}/decidim-generator
-      TEST_IMAGE_NAME: ghcr.io/${{ github.actor }}/decidim-test
-      DEV_IMAGE_NAME: ghcr.io/${{ github.actor }}/decidim-dev
-      APP_IMAGE_NAME: ghcr.io/${{ github.actor }}/decidim
+      GENERATOR_IMAGE_NAME: ghcr.io/decidim/decidim-generator
+      TEST_IMAGE_NAME: ghcr.io/decidim/decidim-test
+      DEV_IMAGE_NAME: ghcr.io/decidim/decidim-dev
+      APP_IMAGE_NAME: ghcr.io/decidim/decidim
       TAG: ${{ github.sha }}
 
     steps:

--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -1,0 +1,18 @@
+ARG base_image=ghcr.io/decidim/decidim-test:latest
+
+FROM $base_image
+LABEL maintainer="info@coditramuntana.com"
+
+RUN apt-get install -y sudo \
+  && apt-get clean
+
+RUN adduser --shell /bin/bash --disabled-password --gecos "" decidim \
+  && adduser decidim sudo \
+  && echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
+
+RUN echo 'Defaults secure_path="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bundle/bin"' > /etc/sudoers.d/secure_path
+RUN chmod 0440 /etc/sudoers.d/secure_path
+
+COPY scripts/entrypoint.sh /usr/local/bin/entrypoint.sh
+
+ENTRYPOINT []

--- a/Dockerfile-test
+++ b/Dockerfile-test
@@ -1,0 +1,28 @@
+ARG base_image=ghcr.io/decidim/decidim-generator:latest
+
+FROM $base_image
+LABEL maintainer="info@coditramuntana.com"
+
+ARG decidim_version
+
+RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
+  && sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list' \
+  && apt-get update \
+  && apt-get install -y google-chrome-stable \
+  && apt-get clean
+
+RUN CHROMEDRIVER_RELEASE=85.0.4183.87 \
+  && CHROMEDRIVER_URL="http://chromedriver.storage.googleapis.com/$CHROMEDRIVER_RELEASE/chromedriver_linux64.zip" \
+  && apt-get install unzip \
+  && curl --silent --show-error --location --fail --retry 3 --output /tmp/chromedriver_linux64.zip $CHROMEDRIVER_URL \
+  && unzip /tmp/chromedriver_linux64.zip chromedriver -d /usr/local/bin \
+  && rm /tmp/chromedriver_linux64.zip
+
+RUN DOCKERIZE_VERSION=v0.6.1 \
+  && wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
+  && tar -C /usr/local/bin -xzvf dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
+  && rm dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz
+
+RUN gem install decidim-dev:${decidim_version} --force
+
+ENTRYPOINT []

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ There's different tags for different usage scenarios:
 
 ## Github Registry Images
 
+** Not yet available** - pending authentication setup: https://github.com/decidim/docker/issues/66
+
 Naming has changed for images published on the new Github flow. We now use different names for images with different purposes, as opposed to using tagging to distinguish between them. Also, the app generator gem is now called `decidim-generator`.
 
 - `decidim-generator:latest` or `decidim-generator:<version>` (eg: `decidim-generator:0.23.1`): the [decidim gem](https://rubygems.org/gems/decidim) with all necessary environment for running it.

--- a/README.md
+++ b/README.md
@@ -1,10 +1,32 @@
 # Docker images for Decidim 
 
-There are two official images available for Decidim on Github Packages: `decidim` and `decidim-generator`.
+We're in the process of adopting Github Actions for our automated image build and publishing, and while that flow currently only publishes to Github Container Registry, there's another earlier flow on circleci publishing images to Docker Hub.
 
-The `decidim` image is a dockerized Decidim app with standard core modules. It can be used for quickly spinning up a local instance and kick the tires, or for deployment if all you need are the core modules.
+Instructions for using the generator and app images can be found below the information on each registry.
 
-The `decidim-generator` image is a base environment with all you need to generate a new Decidim app locally. It is also the base image from which the `decidim` image is built.
+## Docker Hub images
+
+
+We plan to phase out the circleci flow soon, and publish to Docker Hub with Github Actions as well.
+
+You'll find the images here: https://hub.docker.com/r/decidim/decidim/tags
+
+There's different tags for different usage scenarios:
+
+- `decidim:latest` or `decidim:<version>` (eg: `decidim:0.23.1`): the [decidim gem](https://rubygems.org/gems/decidim) with all necessary environment for running it.
+- `decidim:latest-test` or `decidim:<version>-test` (eg: `decidim:0.23.1-test`): the above gem environment plus tooling for testing.
+- `decidim:latest-dev` or `decidim:<version>-dev` (eg: `decidim:0.23.1-dev`): the above plus more configuration for running local dev environment.
+- `decidim:latest-deploy` or `decidim:<version>-deploy` (eg: `decidim:0.23.1-deploy`): actual generated Decidim app to be run locally.
+
+## Github Registry Images
+
+Naming has changed for images published on the new Github flow. We now use different names for images with different purposes, as opposed to using tagging to distinguish between them. Also, the app generator gem is now called `decidim-generator`.
+
+- `decidim-generator:latest` or `decidim-generator:<version>` (eg: `decidim-generator:0.23.1`): the [decidim gem](https://rubygems.org/gems/decidim) with all necessary environment for running it.
+- `decidim-test:latest` or `decidim-test:<version>` (eg: `decidim-test:0.23.1`): the above gem environment plus tooling for testing.
+- `decidim-dev:latest` or `decidim-dev:<version>` (eg: `decidim-dev:0.23.1`): the above plus more configuration for running local dev environment.
+- `decidim:latest` or `decidim:<version>` (eg: `decidim:0.23.1`): actual generated Decidim app to be run locally.
+
 
 ## Using the decidim (app) image
 
@@ -45,12 +67,3 @@ From here on you can follow the steps on the [Getting Started](https://github.co
 The generator image can be used in conjunction with docker-compose, and the core [decidim/decidim](https://github.com/decidim/decidim) repo already offers a [docker-compose.yml](https://github.com/decidim/decidim/blob/develop/docker-compose.yml) file (currently pointing to the Docker Hub `decidim/decidim:latest-dev` image).
 
 It is convenient, but not absolutely mandatory to create a volume for the /usr/local/bundle folder.
-
-## Docker Hub images
-
-We're in the process of adopting Github Actions for our automated image build and publishing, and while that flow currently only publishes to Github Packages, there's another flow on circleci publishing images to Docker Hub.
-
-We plan to phase out the circleci flow soon, and publish to Docker Hub with Github Actions as well.
-
-Meanwhile, be aware that Docker Hub and Github Package images are gradually diverging.
-

--- a/dockerhub/Dockerfile-dev
+++ b/dockerhub/Dockerfile-dev
@@ -13,6 +13,6 @@ RUN adduser --shell /bin/bash --disabled-password --gecos "" decidim \
 RUN echo 'Defaults secure_path="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bundle/bin"' > /etc/sudoers.d/secure_path
 RUN chmod 0440 /etc/sudoers.d/secure_path
 
-COPY scripts/entrypoint.sh /usr/local/bin/entrypoint.sh
+COPY ../scripts/entrypoint.sh /usr/local/bin/entrypoint.sh
 
 ENTRYPOINT []


### PR DESCRIPTION
Includes Dockerfile-test and Dockerfile-dev, closing #62. 

Updates the README to explain differences between Docker Hub and Github Container Registry images, and future plans to publish to both.

~~Temporarily changes the Github Action workflow to publish the images on pull request, to test the CI flow out. This commit will be reverted before opening the PR for review.~~

Can't be tested out while authentication isn't configured, which @tramuntanal and I will handle next week. I'm going to open the PR for review and create an issue for the authentication to keep track of its progress.

**Update** 

Now using decidim-bot to login into container registry.