### PR TITLE
Publish images to Docker Hub through new Github workflow

### DIFF
--- a/.github/workflows/on_push.yml
+++ b/.github/workflows/on_push.yml
@@ -57,12 +57,20 @@ jobs:
         docker tag $GENERATOR_IMAGE_NAME:$TAG $GENERATOR_IMAGE_NAME:latest
         docker tag $GENERATOR_IMAGE_NAME:$TAG $GENERATOR_IMAGE_NAME:$DECIDIM_VERSION
 
-    - name: Publish Image to Github Container Registry
+    - name: Publish decidim-generator Image to Github Container Registry
       uses: azure/docker-login@v1
       with:
         login-server: ghcr.io
         username: decidim-bot
         password: ${{ secrets.CONTAINER_REGISTRY_PAT }}
+    - run: |
+        docker push $GENERATOR_IMAGE_NAME
+
+    - name: Publish decidim-generator Image to Docker Hub
+      uses: docker/login-action@v1
+      with:
+        username: decidimbot
+        password: ${{ secrets.DOCKERHUB_PAT }}
     - run: |
         docker push $GENERATOR_IMAGE_NAME
 
@@ -86,6 +94,14 @@ jobs:
     - run: |
         docker push $TEST_IMAGE_NAME
 
+    - name: Publish decidim-test Image to Docker Hub
+      uses: docker/login-action@v1
+      with:
+        username: decidimbot
+        password: ${{ secrets.DOCKERHUB_PAT }}
+    - run: |
+        docker push $TEST_IMAGE_NAME
+
     - name: Build decidim-dev Image
       env:
         RUBY_VERSION: ${{ steps.ruby-version.outputs.version }}
@@ -103,6 +119,14 @@ jobs:
         login-server: ghcr.io
         username: decidim-bot
         password: ${{ secrets.CONTAINER_REGISTRY_PAT }}
+    - run: |
+        docker push $DEV_IMAGE_NAME
+
+    - name: Publish decidim-dev Image to Docker Hub
+      uses: docker/login-action@v1
+      with:
+        username: decidimbot
+        password: ${{ secrets.DOCKERHUB_PAT }}
     - run: |
         docker push $DEV_IMAGE_NAME
 
@@ -125,3 +149,12 @@ jobs:
         password: ${{ secrets.CONTAINER_REGISTRY_PAT }}
     - run: |
         docker push $APP_IMAGE_NAME
+
+    - name: Publish decidim Image to Docker Hub
+      uses: docker/login-action@v1
+      with:
+        username: decidimbot
+        password: ${{ secrets.DOCKERHUB_PAT }}
+    - run: |
+        docker push $APP_IMAGE_NAME
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-ARG ruby_version
+ARG ruby_version=2.7.1
 
 FROM ruby:${ruby_version}
 LABEL maintainer="info@coditramuntana.com"
 
-ARG decidim_version
+ARG decidim_version=0.23.1
 
 ENV LANG C.UTF-8
 ENV LC_ALL C.UTF-8

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,8 @@ RUN curl -sL https://deb.nodesource.com/setup_10.x | bash - \
 RUN npm install -g npm@6.3.0
 
 RUN gem install bundler --version '>= 2.1.4' \
-  && gem install decidim:${decidim_version}
+  && gem install decidim:${decidim_version} --no-document
 
-ENTRYPOINT ["decidim"]
+CMD ["decidim"]
+
+ENTRYPOINT []

--- a/Dockerfile-test
+++ b/Dockerfile-test
@@ -3,7 +3,7 @@ ARG base_image=ghcr.io/decidim/decidim-generator:latest
 FROM $base_image
 LABEL maintainer="info@coditramuntana.com"
 
-ARG decidim_version
+ARG decidim_version=0.23.1
 
 RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
   && sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list' \


### PR DESCRIPTION
Closes #63. Includes commits from #72 to expedite things.

~~Also depends on DOCKERHUB_PAT being correctly configured (currently it's being interpreted as a password by Docker Hub, instead of a token). cc @andreslucena~~

La DOCKERHUB_PAT ya está configurada 👍 

