### PR TITLE
Fix dockerfile test build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-ARG ruby_version
+ARG ruby_version=2.7.1
 
 FROM ruby:${ruby_version}
 LABEL maintainer="info@coditramuntana.com"
 
-ARG decidim_version
+ARG decidim_version=0.23.1
 
 ENV LANG C.UTF-8
 ENV LC_ALL C.UTF-8

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,8 @@ RUN curl -sL https://deb.nodesource.com/setup_10.x | bash - \
 RUN npm install -g npm@6.3.0
 
 RUN gem install bundler --version '>= 2.1.4' \
-  && gem install decidim:${decidim_version}
+  && gem install decidim:${decidim_version} --no-document
 
-ENTRYPOINT ["decidim"]
+CMD ["decidim"]
+
+ENTRYPOINT []

--- a/Dockerfile-test
+++ b/Dockerfile-test
@@ -3,7 +3,7 @@ ARG base_image=ghcr.io/decidim/decidim-generator:latest
 FROM $base_image
 LABEL maintainer="info@coditramuntana.com"
 
-ARG decidim_version
+ARG decidim_version=0.23.1
 
 RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
   && sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list' \


### PR DESCRIPTION
Fixes building the decidim-test image with it (#71), and allows us to run arbitrary commands against the image (such as bash).