### PR TITLE
Fix image names for Docker Hub. 

### DIFF
--- a/.github/workflows/dockerhub.yml
+++ b/.github/workflows/dockerhub.yml
@@ -10,17 +10,17 @@ on:
     - 'Dockerfile-test'
     - 'Dockerfile-dev'
     - 'Dockerfile-deploy'
-    - '.github/workflows/on_push.yml'
+    - '.github/workflows/dockerhub.yml'
 
 jobs:
   build-publish:
     name: Build & Publish Docker Images
     runs-on: ubuntu-latest
     env:
-      GENERATOR_IMAGE_NAME: ghcr.io/decidim/decidim-generator
-      TEST_IMAGE_NAME: ghcr.io/decidim/decidim-test
-      DEV_IMAGE_NAME: ghcr.io/decidim/decidim-dev
-      APP_IMAGE_NAME: ghcr.io/decidim/decidim
+      GENERATOR_IMAGE_NAME: decidim/decidim-generator
+      TEST_IMAGE_NAME: decidim/decidim-test
+      DEV_IMAGE_NAME: decidim/decidim-dev
+      APP_IMAGE_NAME: decidim/decidim
       TAG: ${{ github.sha }}
 
     steps:
@@ -57,15 +57,6 @@ jobs:
         docker tag $GENERATOR_IMAGE_NAME:$TAG $GENERATOR_IMAGE_NAME:latest
         docker tag $GENERATOR_IMAGE_NAME:$TAG $GENERATOR_IMAGE_NAME:$DECIDIM_VERSION
 
-    - name: Publish decidim-generator Image to Github Container Registry
-      uses: azure/docker-login@v1
-      with:
-        login-server: ghcr.io
-        username: decidim-bot
-        password: ${{ secrets.CONTAINER_REGISTRY_PAT }}
-    - run: |
-        docker push $GENERATOR_IMAGE_NAME
-
     - name: Publish decidim-generator Image to Docker Hub
       uses: docker/login-action@v1
       with:
@@ -84,15 +75,6 @@ jobs:
         -t $TEST_IMAGE_NAME:$TAG .
         docker tag $TEST_IMAGE_NAME:$TAG $TEST_IMAGE_NAME:latest
         docker tag $TEST_IMAGE_NAME:$TAG $TEST_IMAGE_NAME:$DECIDIM_VERSION
-
-    - name: Publish decidim-test Image to Github Container Registry
-      uses: azure/docker-login@v1
-      with:
-        login-server: ghcr.io
-        username: decidim-bot
-        password: ${{ secrets.CONTAINER_REGISTRY_PAT }}
-    - run: |
-        docker push $TEST_IMAGE_NAME
 
     - name: Publish decidim-test Image to Docker Hub
       uses: docker/login-action@v1
@@ -113,15 +95,6 @@ jobs:
         docker tag $DEV_IMAGE_NAME:$TAG $DEV_IMAGE_NAME:latest
         docker tag $DEV_IMAGE_NAME:$TAG $DEV_IMAGE_NAME:$DECIDIM_VERSION
 
-    - name: Publish decidim-dev Image to Github Container Registry
-      uses: azure/docker-login@v1
-      with:
-        login-server: ghcr.io
-        username: decidim-bot
-        password: ${{ secrets.CONTAINER_REGISTRY_PAT }}
-    - run: |
-        docker push $DEV_IMAGE_NAME
-
     - name: Publish decidim-dev Image to Docker Hub
       uses: docker/login-action@v1
       with:
@@ -141,15 +114,6 @@ jobs:
         docker tag $APP_IMAGE_NAME:$TAG $APP_IMAGE_NAME:latest
         docker tag $APP_IMAGE_NAME:$TAG $APP_IMAGE_NAME:$DECIDIM_VERSION
 
-    - name: Publish decidim Image to Github Container Registry
-      uses: azure/docker-login@v1
-      with:
-        login-server: ghcr.io
-        username: decidim-bot
-        password: ${{ secrets.CONTAINER_REGISTRY_PAT }}
-    - run: |
-        docker push $APP_IMAGE_NAME
-
     - name: Publish decidim Image to Docker Hub
       uses: docker/login-action@v1
       with:
@@ -157,4 +121,3 @@ jobs:
         password: ${{ secrets.DOCKERHUB_PAT }}
     - run: |
         docker push $APP_IMAGE_NAME
-

--- a/.github/workflows/github_registry.yml
+++ b/.github/workflows/github_registry.yml
@@ -1,0 +1,127 @@
+name: CI
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+    - master
+    paths:
+    - 'Dockerfile'
+    - 'Dockerfile-test'
+    - 'Dockerfile-dev'
+    - 'Dockerfile-deploy'
+    - '.github/workflows/github_registry.yml'
+
+jobs:
+  build-publish:
+    name: Build & Publish Docker Images
+    runs-on: ubuntu-latest
+    env:
+      GENERATOR_IMAGE_NAME: ghcr.io/decidim/decidim-generator
+      TEST_IMAGE_NAME: ghcr.io/decidim/decidim-test
+      DEV_IMAGE_NAME: ghcr.io/decidim/decidim-dev
+      APP_IMAGE_NAME: ghcr.io/decidim/decidim
+      TAG: ${{ github.sha }}
+
+    steps:
+    - name: Fetch Decidim Tag
+      id: decidim-tag
+      uses: oprypin/find-latest-tag@v1
+      with:
+        repository: decidim/decidim
+        releases-only: true
+
+    - name: Set Ruby Version
+      id: ruby-version
+      env:
+        RUBY_VERSION_URL: https://raw.githubusercontent.com/decidim/decidim/${{ steps.decidim-tag.outputs.tag }}/.ruby-version
+      run: |
+        echo ::set-output name=version::$(curl -s $RUBY_VERSION_URL)
+
+    - name: Set Decidim Version
+      id: decidim-version
+      run: echo ::set-output name=version::$(echo ${{ steps.decidim-tag.outputs.tag }} | cut -c2-)
+      
+    - name: Checkout Our Repo
+      uses: actions/checkout@v2
+
+    - name: Build decidim-generator Image
+      env:
+        RUBY_VERSION: ${{ steps.ruby-version.outputs.version }}
+        DECIDIM_VERSION: ${{ steps.decidim-version.outputs.version }}
+      run: |
+        docker build \
+        --build-arg ruby_version=$RUBY_VERSION \
+        --build-arg decidim_version=$DECIDIM_VERSION \
+        -t $GENERATOR_IMAGE_NAME:$TAG .
+        docker tag $GENERATOR_IMAGE_NAME:$TAG $GENERATOR_IMAGE_NAME:latest
+        docker tag $GENERATOR_IMAGE_NAME:$TAG $GENERATOR_IMAGE_NAME:$DECIDIM_VERSION
+
+    - name: Publish decidim-generator Image to Github Container Registry
+      uses: azure/docker-login@v1
+      with:
+        login-server: ghcr.io
+        username: decidim-bot
+        password: ${{ secrets.CONTAINER_REGISTRY_PAT }}
+    - run: |
+        docker push $GENERATOR_IMAGE_NAME
+
+    - name: Build decidim-test Image
+      env:
+        RUBY_VERSION: ${{ steps.ruby-version.outputs.version }}
+        DECIDIM_VERSION: ${{ steps.decidim-version.outputs.version }}
+      run: |
+        docker build \
+        --file Dockerfile-test \
+        -t $TEST_IMAGE_NAME:$TAG .
+        docker tag $TEST_IMAGE_NAME:$TAG $TEST_IMAGE_NAME:latest
+        docker tag $TEST_IMAGE_NAME:$TAG $TEST_IMAGE_NAME:$DECIDIM_VERSION
+
+    - name: Publish decidim-test Image to Github Container Registry
+      uses: azure/docker-login@v1
+      with:
+        login-server: ghcr.io
+        username: decidim-bot
+        password: ${{ secrets.CONTAINER_REGISTRY_PAT }}
+    - run: |
+        docker push $TEST_IMAGE_NAME
+
+    - name: Build decidim-dev Image
+      env:
+        RUBY_VERSION: ${{ steps.ruby-version.outputs.version }}
+        DECIDIM_VERSION: ${{ steps.decidim-version.outputs.version }}
+      run: |
+        docker build \
+        --file Dockerfile-dev \
+        -t $DEV_IMAGE_NAME:$TAG .
+        docker tag $DEV_IMAGE_NAME:$TAG $DEV_IMAGE_NAME:latest
+        docker tag $DEV_IMAGE_NAME:$TAG $DEV_IMAGE_NAME:$DECIDIM_VERSION
+
+    - name: Publish decidim-dev Image to Github Container Registry
+      uses: azure/docker-login@v1
+      with:
+        login-server: ghcr.io
+        username: decidim-bot
+        password: ${{ secrets.CONTAINER_REGISTRY_PAT }}
+    - run: |
+        docker push $DEV_IMAGE_NAME
+
+    - name: Build decidim (app) Image
+      env:
+        RUBY_VERSION: ${{ steps.ruby-version.outputs.version }}
+        DECIDIM_VERSION: ${{ steps.decidim-version.outputs.version }}
+      run: |
+        docker build \
+        --file Dockerfile-deploy \
+        -t $APP_IMAGE_NAME:$TAG .
+        docker tag $APP_IMAGE_NAME:$TAG $APP_IMAGE_NAME:latest
+        docker tag $APP_IMAGE_NAME:$TAG $APP_IMAGE_NAME:$DECIDIM_VERSION
+
+    - name: Publish decidim Image to Github Container Registry
+      uses: azure/docker-login@v1
+      with:
+        login-server: ghcr.io
+        username: decidim-bot
+        password: ${{ secrets.CONTAINER_REGISTRY_PAT }}
+    - run: |
+        docker push $APP_IMAGE_NAME


### PR DESCRIPTION
Images are being pushed to both GHCR and Docker Hub with the same name, which means they end up missing the decidim/decidim repository on the latter (and so aren't published there).

This PR separates both flows and names images according to their registry repos in each one.