### PR TITLE
Fix decidim-dev and Docker Hub publishing

### DIFF
--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -1,0 +1,16 @@
+#!/bin/sh -x
+
+USER_UID=$(stat -c %u /code/Gemfile)
+USER_GID=$(stat -c %g /code/Gemfile)
+
+export USER_UID
+export USER_GID
+
+usermod -u "$USER_UID" decidim 2> /dev/null
+groupmod -g "$USER_GID" decidim 2> /dev/null
+usermod -g "$USER_GID" decidim 2> /dev/null
+
+chown -R -h "$USER_UID" "$BUNDLE_PATH"
+chgrp -R -h "$USER_GID" "$BUNDLE_PATH"
+
+/usr/bin/sudo -EH -u decidim "$@"


### PR DESCRIPTION
In phasing out the circleci flow we ended up also deleting decidim-dev's entrypoint.sh by mistake, and this fell through the cracks as we were no longer testing the builds on pull request, so we only found out after merging.

This PR adds the script back ~~, and temporarily tests the builds for Docker Hub on the pull_request, hence the draft status for the PR. Once the builds are confimed to be ok, I'll change it back to trigger on push, ans open the PR so it can be reviewed after xmas.~~, fixing the decidim-dev build and by consequence, the remainder builds that came after it.

Update: In the process I've also updated Docker Hub to have a separate repository for each image, as DH requires, so the images were finally pushed there.