### PR TITLE
Fix entrypoint.sh permissions for the decidim-dev image

### DIFF
--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -15,4 +15,6 @@ RUN chmod 0440 /etc/sudoers.d/secure_path
 
 COPY scripts/entrypoint.sh /usr/local/bin/entrypoint.sh
 
+RUN chmod +x /usr/local/bin/entrypoint.sh
+
 ENTRYPOINT []


### PR DESCRIPTION
Fixes https://github.com/decidim/docker/issues/76 by making entrypoint.sh executable