### PR TITLE
Push all image tags on builds

### DIFF
--- a/.github/workflows/dockerhub.yml
+++ b/.github/workflows/dockerhub.yml
@@ -120,4 +120,4 @@ jobs:
         username: decidimbot
         password: ${{ secrets.DOCKERHUB_PAT }}
     - run: |
-        docker push $APP_IMAGE_NAME
+        docker push --all-tags $APP_IMAGE_NAME

--- a/.github/workflows/github_registry.yml
+++ b/.github/workflows/github_registry.yml
@@ -124,4 +124,4 @@ jobs:
         username: decidim-bot
         password: ${{ secrets.CONTAINER_REGISTRY_PAT }}
     - run: |
-        docker push $APP_IMAGE_NAME
+        docker push --all-tags $APP_IMAGE_NAME


### PR DESCRIPTION
The [latest build](https://github.com/decidim/docker/runs/1887499929?check_suite_focus=true) didn't push the last 0.23.2 version tag, though it did correctly detect it:

```bash
echo ::set-output name=version::$(echo v0.23.2 | cut -c2-)
```

This adds the `--all-tags` option to `docker push`. ~~Testing it first on pull request, and so setting this to draft until it's confirmed to be working.~~

Confirmed working. Here are the builds:

https://github.com/decidim/docker/actions/runs/561383630
https://github.com/decidim/docker/actions/runs/561383631

And correctly tagged images:

https://github.com/orgs/decidim/packages/container/decidim/versions
https://hub.docker.com/r/decidim/decidim/tags?page=1&ordering=last_updated

I've switched the workflow back to `on.push` and the PR is ready to merge

