### PR TITLE
Remove rake db:environment:set statement from hello-world.sh

### DIFF
--- a/scripts/hello-world.sh
+++ b/scripts/hello-world.sh
@@ -1,7 +1,6 @@
 #!/bin/sh
 set -e
- 
-bundle exec rake db:environment:set RAILS_ENV=development
+
 # runs db:drop, db:create and db:migrate.
 # We can't use db:schema:load because we don't have the db/schema.rb
 # file when we create the app for the first time and migrations haven't


### PR DESCRIPTION
It's breaking `docker-compose up`, since it expects the database to exist.

I have no idea how this was working when I tested it before 🤔 