### PR TITLE
Bump node version from 10 to 16

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 ARG base_image=ghcr.io/decidim/decidim-generator:latest
 
 FROM $base_image
-LABEL maintainer="info@coditramuntana.com"
+LABEL maintainer="hola@decidim.org"
 
 RUN decidim .
 RUN bundle check || bundle install

--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -1,7 +1,7 @@
 ARG base_image=ghcr.io/decidim/decidim-test:latest
 
 FROM $base_image
-LABEL maintainer="info@coditramuntana.com"
+LABEL maintainer="hola@decidim.org"
 
 RUN apt-get install -y sudo \
   && apt-get clean

--- a/Dockerfile-generator
+++ b/Dockerfile-generator
@@ -25,7 +25,7 @@ RUN  curl -sL https://dl.yarnpkg.com/debian/pubkey.gpg | gpg --dearmor | tee /us
   && apt-get install yarn \
   && apt-get clean
 
-RUN gem install bundler --version '>= 2.1.4' \
+RUN gem install bundler --version '>= 2.3.12' \
   && gem install decidim:${decidim_version} --no-document
 
 CMD ["decidim"]

--- a/Dockerfile-generator
+++ b/Dockerfile-generator
@@ -3,7 +3,7 @@ ARG ruby_version=2.7.5
 FROM ruby:${ruby_version}
 LABEL maintainer="hola@decidim.org"
 
-ARG decidim_version=0.23.1
+ARG decidim_version=0.26.2
 
 ENV LANG C.UTF-8
 ENV LC_ALL C.UTF-8

--- a/Dockerfile-generator
+++ b/Dockerfile-generator
@@ -17,7 +17,7 @@ RUN curl -sL https://deb.nodesource.com/setup_16.x | bash - \
   && apt-get install -y nodejs \
   && apt-get clean
 
-RUN npm install -g npm@6.3.0
+RUN npm install -g npm@7.21.1
 
 RUN  curl -sL https://dl.yarnpkg.com/debian/pubkey.gpg | gpg --dearmor | tee /usr/share/keyrings/yarnkey.gpg >/dev/null \
   && echo "deb [signed-by=/usr/share/keyrings/yarnkey.gpg] https://dl.yarnpkg.com/debian stable main" | tee /etc/apt/sources.list.d/yarn.list \

--- a/Dockerfile-generator
+++ b/Dockerfile-generator
@@ -19,6 +19,12 @@ RUN curl -sL https://deb.nodesource.com/setup_16.x | bash - \
 
 RUN npm install -g npm@6.3.0
 
+RUN  curl -sL https://dl.yarnpkg.com/debian/pubkey.gpg | gpg --dearmor | tee /usr/share/keyrings/yarnkey.gpg >/dev/null \
+  && echo "deb [signed-by=/usr/share/keyrings/yarnkey.gpg] https://dl.yarnpkg.com/debian stable main" | tee /etc/apt/sources.list.d/yarn.list \
+  && apt-get update \
+  && apt-get install yarn \
+  && apt-get clean
+
 RUN gem install bundler --version '>= 2.1.4' \
   && gem install decidim:${decidim_version} --no-document
 

--- a/Dockerfile-generator
+++ b/Dockerfile-generator
@@ -1,7 +1,7 @@
 ARG ruby_version=2.7.1
 
 FROM ruby:${ruby_version}
-LABEL maintainer="info@coditramuntana.com"
+LABEL maintainer="hola@decidim.org"
 
 ARG decidim_version=0.23.1
 

--- a/Dockerfile-generator
+++ b/Dockerfile-generator
@@ -13,7 +13,7 @@ WORKDIR /code
 RUN apt-get install -y git imagemagick wget \
   && apt-get clean
 
-RUN curl -sL https://deb.nodesource.com/setup_10.x | bash - \
+RUN curl -sL https://deb.nodesource.com/setup_16.x | bash - \
   && apt-get install -y nodejs \
   && apt-get clean
 

--- a/Dockerfile-generator
+++ b/Dockerfile-generator
@@ -18,12 +18,7 @@ RUN curl -sL https://deb.nodesource.com/setup_16.x | bash - \
   && apt-get clean
 
 RUN npm install -g npm@7.21.1
-
-RUN  curl -sL https://dl.yarnpkg.com/debian/pubkey.gpg | gpg --dearmor | tee /usr/share/keyrings/yarnkey.gpg >/dev/null \
-  && echo "deb [signed-by=/usr/share/keyrings/yarnkey.gpg] https://dl.yarnpkg.com/debian stable main" | tee /etc/apt/sources.list.d/yarn.list \
-  && apt-get update \
-  && apt-get install yarn \
-  && apt-get clean
+RUN npm install -g yarn@1.22.18
 
 RUN gem install bundler --version '>= 2.3.12' \
   && gem install decidim:${decidim_version} --no-document

--- a/Dockerfile-generator
+++ b/Dockerfile-generator
@@ -1,4 +1,4 @@
-ARG ruby_version=2.7.1
+ARG ruby_version=2.7.5
 
 FROM ruby:${ruby_version}
 LABEL maintainer="hola@decidim.org"

--- a/Dockerfile-test
+++ b/Dockerfile-test
@@ -3,7 +3,7 @@ ARG base_image=ghcr.io/decidim/decidim-generator:latest
 FROM $base_image
 LABEL maintainer="hola@decidim.org"
 
-ARG decidim_version=0.23.1
+ARG decidim_version=0.26.2
 
 RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
   && sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list' \

--- a/Dockerfile-test
+++ b/Dockerfile-test
@@ -1,7 +1,7 @@
 ARG base_image=ghcr.io/decidim/decidim-generator:latest
 
 FROM $base_image
-LABEL maintainer="info@coditramuntana.com"
+LABEL maintainer="hola@decidim.org"
 
 ARG decidim_version=0.23.1
 


### PR DESCRIPTION

This week on Element/Matrix.org, someone mentioned that we weren't releasing docker images for the past 10 months. I've reported it yesterday at #93. This PR fixes it. 

The problem that we have is with the Node.js version that we were using an unsupported one. This can be checked by running the following command: 

```bash
docker build --no-cache --build-arg ruby_version=2.7.5 --build-arg decidim_version=0.26.0 --file Dockerfile-generator -t decidim-generator-v0.26.0 . 
```

<details>
<summary>Click to see full traceback</summary>


Sending build context to Docker daemon  315.4kB
Step 1/13 : ARG ruby_version=2.7.1
Step 2/13 : FROM ruby:${ruby_version}
 ---> e7c13114124c
Step 3/13 : LABEL maintainer="info@coditramuntana.com"
 ---> Running in a1b4a98284b4
Removing intermediate container a1b4a98284b4
 ---> 3b8c0f30d762
Step 4/13 : ARG decidim_version=0.23.1
 ---> Running in cc0f2bbe68ff
Removing intermediate container cc0f2bbe68ff
 ---> 4f7ba645d00d
Step 5/13 : ENV LANG C.UTF-8
 ---> Running in 59ec19e62f68
Removing intermediate container 59ec19e62f68
 ---> c577b92d120b
Step 6/13 : ENV LC_ALL C.UTF-8
 ---> Running in 8baf12cd0039
Removing intermediate container 8baf12cd0039
 ---> 6c21417a7413
Step 7/13 : WORKDIR /code
 ---> Running in 49ac14f23174
Removing intermediate container 49ac14f23174
 ---> 3ba662970755
Step 8/13 : RUN apt-get install -y git imagemagick wget   && apt-get clean
 ---> Running in 2e4a9fc8d82d
Reading package lists...
Building dependency tree...
Reading state information...
git is already the newest version (1:2.30.2-1).
imagemagick is already the newest version (8:6.9.11.60+dfsg-1.3).
wget is already the newest version (1.21-1+deb11u1).
0 upgraded, 0 newly installed, 0 to remove and 0 not upgraded.
Removing intermediate container 2e4a9fc8d82d
 ---> c87e2dd0d527
Step 9/13 : RUN curl -sL https://deb.nodesource.com/setup_10.x | bash -   && apt-get install -y nodejs   && apt-get clean
 ---> Running in 5b7b679b0b23

================================================================================
================================================================================

                              DEPRECATION WARNING                            

  Node.js 10.x is no longer actively supported!

  You will not receive security or critical stability updates for this version.

  You should migrate to a supported version of Node.js as soon as possible.
  Use the installation script that corresponds to the version of Node.js you
  wish to install. e.g.

   * https://deb.nodesource.com/setup_12.x — Node.js 12 LTS "Erbium"
   * https://deb.nodesource.com/setup_14.x — Node.js 14 LTS "Fermium" (recommended)
   * https://deb.nodesource.com/setup_16.x — Node.js 16 "Gallium"

  Please see https://github.com/nodejs/Release for details about which
  version may be appropriate for you.

  The NodeSource Node.js distributions repository contains
  information both about supported versions of Node.js and supported Linux
  distributions. To learn more about usage, see the repository:
    https://github.com/nodesource/distributions

================================================================================
================================================================================

Continuing in 20 seconds ...


## Installing the NodeSource Node.js 10.x repo...


## Populating apt-get cache...

+ apt-get update
Get:1 http://security.debian.org/debian-security bullseye-security InRelease [44.1 kB]
Get:2 http://deb.debian.org/debian bullseye InRelease [116 kB]
Get:3 http://deb.debian.org/debian bullseye-updates InRelease [39.4 kB]
Get:4 http://security.debian.org/debian-security bullseye-security/main amd64 Packages [124 kB]
Get:5 http://deb.debian.org/debian bullseye/main amd64 Packages [8182 kB]
Get:6 http://deb.debian.org/debian bullseye-updates/main amd64 Packages [2596 B]
Fetched 8508 kB in 1s (6095 kB/s)
Reading package lists...

## Installing packages required for setup: lsb-release...

+ apt-get install -y lsb-release > /dev/null 2>&1

## Confirming "bullseye" is supported...

+ curl -sLf -o /dev/null 'https://deb.nodesource.com/node_10.x/dists/bullseye/Release'

## Adding the NodeSource signing key to your keyring...

+ curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | gpg --dearmor | tee /usr/share/keyrings/nodesource.gpg >/dev/null

## Creating apt sources list file for the NodeSource Node.js 10.x repo...

+ echo 'deb [signed-by=/usr/share/keyrings/nodesource.gpg] https://deb.nodesource.com/node_10.x bullseye main' > /etc/apt/sources.list.d/nodesource.list
+ echo 'deb-src [signed-by=/usr/share/keyrings/nodesource.gpg] https://deb.nodesource.com/node_10.x bullseye main' >> /etc/apt/sources.list.d/nodesource.list

## Running `apt-get update` for you...

+ apt-get update
Hit:1 http://security.debian.org/debian-security bullseye-security InRelease
Hit:2 http://deb.debian.org/debian bullseye InRelease
Hit:3 http://deb.debian.org/debian bullseye-updates InRelease
Get:4 https://deb.nodesource.com/node_10.x bullseye InRelease [4586 B]
Get:5 https://deb.nodesource.com/node_10.x bullseye/main amd64 Packages [769 B]
Fetched 5355 B in 1s (5064 B/s)
Reading package lists...

## Run `sudo apt-get install -y nodejs` to install Node.js 10.x and npm
## You may also need development tools to build native addons:
     sudo apt-get install gcc g++ make
## To install the Yarn package manager, run:
     curl -sL https://dl.yarnpkg.com/debian/pubkey.gpg | gpg --dearmor | sudo tee /usr/share/keyrings/yarnkey.gpg >/dev/null
     echo "deb [signed-by=/usr/share/keyrings/yarnkey.gpg] https://dl.yarnpkg.com/debian stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
     sudo apt-get update && sudo apt-get install yarn


Reading package lists...
Building dependency tree...
Reading state information...
The following additional packages will be installed:
  javascript-common libc-ares2 libjs-highlight.js libnode72 libuv1 nodejs-doc
Suggested packages:
  apache2 | lighttpd | httpd npm
The following NEW packages will be installed:
  javascript-common libc-ares2 libjs-highlight.js libnode72 libuv1 nodejs
  nodejs-doc
0 upgraded, 7 newly installed, 0 to remove and 2 not upgraded.
Need to get 11.7 MB of archives.
After this operation, 50.9 MB of additional disk space will be used.
Get:1 http://deb.debian.org/debian bullseye/main amd64 javascript-common all 11+nmu1 [6260 B]
Get:2 http://deb.debian.org/debian bullseye/main amd64 libc-ares2 amd64 1.17.1-1+deb11u1 [102 kB]
Get:3 http://deb.debian.org/debian bullseye/main amd64 libjs-highlight.js all 9.18.5+dfsg1-1 [397 kB]
Get:4 http://deb.debian.org/debian bullseye/main amd64 libuv1 amd64 1.40.0-2 [132 kB]
Get:5 http://deb.debian.org/debian bullseye/main amd64 libnode72 amd64 12.22.5~dfsg-2~11u1 [8333 kB]
Get:6 http://deb.debian.org/debian bullseye/main amd64 nodejs amd64 12.22.5~dfsg-2~11u1 [147 kB]
Get:7 http://deb.debian.org/debian bullseye/main amd64 nodejs-doc all 12.22.5~dfsg-2~11u1 [2545 kB]
debconf: delaying package configuration, since apt-utils is not installed
Fetched 11.7 MB in 0s (25.2 MB/s)
Selecting previously unselected package javascript-common.
(Reading database ... 22761 files and directories currently installed.)
Preparing to unpack .../0-javascript-common_11+nmu1_all.deb ...
Unpacking javascript-common (11+nmu1) ...
Selecting previously unselected package libc-ares2:amd64.
Preparing to unpack .../1-libc-ares2_1.17.1-1+deb11u1_amd64.deb ...
Unpacking libc-ares2:amd64 (1.17.1-1+deb11u1) ...
Selecting previously unselected package libjs-highlight.js.
Preparing to unpack .../2-libjs-highlight.js_9.18.5+dfsg1-1_all.deb ...
Unpacking libjs-highlight.js (9.18.5+dfsg1-1) ...
Selecting previously unselected package libuv1:amd64.
Preparing to unpack .../3-libuv1_1.40.0-2_amd64.deb ...
Unpacking libuv1:amd64 (1.40.0-2) ...
Selecting previously unselected package libnode72:amd64.
Preparing to unpack .../4-libnode72_12.22.5~dfsg-2~11u1_amd64.deb ...
Unpacking libnode72:amd64 (12.22.5~dfsg-2~11u1) ...
Selecting previously unselected package nodejs.
Preparing to unpack .../5-nodejs_12.22.5~dfsg-2~11u1_amd64.deb ...
Unpacking nodejs (12.22.5~dfsg-2~11u1) ...
Selecting previously unselected package nodejs-doc.
Preparing to unpack .../6-nodejs-doc_12.22.5~dfsg-2~11u1_all.deb ...
Unpacking nodejs-doc (12.22.5~dfsg-2~11u1) ...
Setting up javascript-common (11+nmu1) ...
Setting up libc-ares2:amd64 (1.17.1-1+deb11u1) ...
Setting up libuv1:amd64 (1.40.0-2) ...
Setting up libjs-highlight.js (9.18.5+dfsg1-1) ...
Setting up libnode72:amd64 (12.22.5~dfsg-2~11u1) ...
Setting up nodejs-doc (12.22.5~dfsg-2~11u1) ...
Setting up nodejs (12.22.5~dfsg-2~11u1) ...
update-alternatives: using /usr/bin/nodejs to provide /usr/bin/js (js) in auto mode
Processing triggers for libc-bin (2.31-13+deb11u3) ...
Removing intermediate container 5b7b679b0b23
 ---> e96338780783
Step 10/13 : RUN npm install -g npm@6.3.0
 ---> Running in 53be5a1b2e1e
/bin/sh: 1: npm: not found
The command '/bin/sh -c npm install -g npm@6.3.0' returned a non-zero code: 127


</details>

You'll see a DEPRECATION WARNING about this and after that it'll fail with the same error as in CI:

> 
> Step 10/13 : RUN npm install -g npm@6.3.0
>  ---> Running in 53be5a1b2e1e
> /bin/sh: 1: npm: not found
> The command '/bin/sh -c npm install -g npm@6.3.0' returned a non-zero code: 127
> 

The DEPRECATION WARNING is pretty clear: 

> 
> ================================================================================
> 
>                               DEPRECATION WARNING                            
> 
>   Node.js 10.x is no longer actively supported!
> 
>   You will not receive security or critical stability updates for this version.
> 
>   You should migrate to a supported version of Node.js as soon as possible.
>   Use the installation script that corresponds to the version of Node.js you
>   wish to install. e.g.
> 
>    * https://deb.nodesource.com/setup_12.x — Node.js 12 LTS "Erbium"
>    * https://deb.nodesource.com/setup_14.x — Node.js 14 LTS "Fermium" (recommended)
>    * https://deb.nodesource.com/setup_16.x — Node.js 16 "Gallium"
> 
>   Please see https://github.com/nodejs/Release for details about which
>   version may be appropriate for you.
> 
>   The NodeSource Node.js distributions repository contains
>   information both about supported versions of Node.js and supported Linux
>   distributions. To learn more about usage, see the repository:
>     https://github.com/nodesource/distributions
> 
> ================================================================================

Note that even though in this warning they recommend using Node.js 14, Decidim is compatible with Node.js 16, so that's the version that I used

So this PR bumps this version, and also does a couple more minor things: 

1. Change the maintainer label (this was from the company that maintained decidim in 2020) 
2. Bump ruby and decidim versions (even though they weren't actually used as they changed with the --build-arg, but it doesn't hurt to do that