### PR TITLE
Add production compose setup with environment variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+# Database configuration
+DB_USER=user
+DB_PASSWORD=pass
+DB_NAME=decidim-production-db 

--- a/README.md
+++ b/README.md
@@ -89,6 +89,12 @@ docker run -it --rm \
   ghcr.io/decidim/decidim:latest
 ```
 
+Alternatively, use our production compose setup:
+- `docker-compose.prod.yml` - Production-ready compose file
+- `.env.example` - Example environment variables
+
+Copy `.env.example` to `.env` and configure your database credentials before running `docker-compose -f docker-compose.prod.yml up`.
+
 ## Using the decidim-generator image
 
 With this image you can generate a new Decidim application:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,23 @@
+version: '3'
+
+services:
+  decidim:
+    image: ghcr.io/decidim/decidim:latest
+    ports:
+      - 3000:3000
+    environment:
+      - DATABASE_URL=postgres://${DB_USER}:${DB_PASSWORD}@pg:5432/${DB_NAME}
+    depends_on:
+      - pg
+
+  pg:
+    image: postgres:14
+    volumes:
+      - pg-data:/var/lib/postgresql/data
+    environment:
+      - POSTGRES_USER=${DB_USER}
+      - POSTGRES_PASSWORD=${DB_PASSWORD}
+      - POSTGRES_DB=${DB_NAME}
+
+volumes:
+  pg-data: {} 


### PR DESCRIPTION
   This PR adds:
   - A production-ready docker-compose file (docker-compose.prod.yml)
   - An example environment file (.env.example)
   - Updated README with production deployment instructions
   
   These changes make it easier to deploy Decidim in production using docker-compose.