### PR TITLE
Change ruby base image to not only use bookworm and use trixie

### DIFF
--- a/Dockerfile-generator
+++ b/Dockerfile-generator
@@ -1,6 +1,6 @@
 ARG ruby_version=3.3.4
 
-FROM ruby:${ruby_version}-bookworm
+FROM ruby:${ruby_version}
 LABEL maintainer="hola@decidim.org"
 
 ARG decidim_version=30.2


### PR DESCRIPTION
Since there were some problems with the `wkhtmltopdf` binary, we had set the ruby base image to use bookworm, but since it's not used by Decidim since the 0.30 we can savely use trixie.