### PR TITLE
Use https with git in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ This repo includes a [docker-compose.yml](docker-compose.yml) file with:
 By cloning the repo and then running `docker-compose up`, you'll get a fully functional Decidim app complete with seed data, accessible at http://localhost:3000.
 
 ```bash
-git clone git@github.com:decidim/docker.git decidim-docker
+git clone https://github.com/decidim/docker.git decidim-docker
 cd decidim-docker
 docker-compose up
 ```


### PR DESCRIPTION
The git protocol was outdated long ago in git and just don't work here (gentoo linux). Use https instead.