### PR TITLE
Fix PostgreSQL image version to 17

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       - pg
       - redis
   pg:
-    image: postgres
+    image: postgres:17
     volumes:
       - pg-data:/var/lib/postgresql/data
     environment:


### PR DESCRIPTION
The latest og version that can be pulled from the docker registry is 18.
Unfortunately, there is a breaking change.
I got this error:
```
pg-1     | ********************************************************************************
pg-1     | Error: in 18+, these Docker images are configured to store database data in a
pg-1     |        format which is compatible with "pg_ctlcluster" (specifically, using
pg-1     |        major-version-specific directory names).  This better reflects how
pg-1     |        PostgreSQL itself works, and how upgrades are to be performed.
pg-1     |
pg-1     |        See also https://github.com/docker-library/postgres/pull/1259
pg-1     |
pg-1     |        Counter to that, there appears to be PostgreSQL data in:
pg-1     |          /var/lib/postgresql/data (unused mount/volume)
pg-1     |
pg-1     |        This is usually the result of upgrading the Docker image without
pg-1     |        upgrading the underlying database using "pg_upgrade" (which requires both
pg-1     |        versions).
pg-1     |
pg-1     |        The suggested container configuration for 18+ is to place a single mount
pg-1     |        at /var/lib/postgresql which will then place PostgreSQL data in a
pg-1     |        subdirectory, allowing usage of "pg_upgrade --link" without mount point
pg-1     |        boundary issues.
pg-1     |
pg-1     |        See https://github.com/docker-library/postgres/issues/37 for a (long)
pg-1     |        discussion around this process, and suggestions for how to do so.
```

This PR fixes the pg version, which sloves the issue.