### PR TITLE
Fix docker compose instructions

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,23 +13,37 @@ services:
       # Makes our entrypoint scripts available to the container
       # under /code/vendor
       - ./scripts:/code/vendor
+    depends_on:
+      postgres:
+        condition: service_healthy
     environment:
       - RAILS_ENV=development
-      - DATABASE_HOST=pg
+      - DATABASE_HOST=postgres
       - DATABASE_USERNAME=postgres
+      - DATABASE_PASSWORD=postgres
     links:
-      - pg
+      - postgres
       - redis
-  pg:
-    image: postgres
+
+  postgres:
+    image: postgres:16.1
     volumes:
-      - pg-data:/var/lib/postgresql/data
+      - postgres-data:/var/lib/postgresql/data
+    networks:
+      - default
     environment:
-      - POSTGRES_HOST_AUTH_METHOD=trust
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=postgres
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
   redis:
     image: redis
     volumes:
       - redis-data:/data
 volumes:
-  pg-data: {}
+  postgres-data: {}
   redis-data: {}


### PR DESCRIPTION
I wanted to provide quick instructions to someone for using  a demo of Decidim, but when I checked the docker-compose locally I noticed that it didn't work out-of-the-box with the instructions that we have in the README of this repository. This PR fixes it.

## Testing

Same instructions that we have in the README

```
git clone git@github.com:decidim/docker.git decidim-docker
cd decidim-docker
docker-compose up
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated database service configuration with health checks for improved reliability and readiness verification.
  * Configured service dependencies to ensure proper startup sequence.
  * Updated database connection settings and added credential management for enhanced security.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->