### PR TITLE
Add multi-architecture (amd64 + arm64) Docker builds

### DIFF
--- a/.github/workflows/dockerhub.yml
+++ b/.github/workflows/dockerhub.yml
@@ -12,17 +12,20 @@ on:
     - 'Dockerfile-generator'
     - '.github/workflows/dockerhub.yml'
 
-jobs:
-  build-publish:
-    name: Build & Publish Docker Images
-    runs-on: ubuntu-latest
-    env:
-      GENERATOR_IMAGE_NAME: decidim/decidim-generator
-      TEST_IMAGE_NAME: decidim/decidim-test
-      DEV_IMAGE_NAME: decidim/decidim-dev
-      APP_IMAGE_NAME: decidim/decidim
-      TAG: ${{ github.sha }}
+env:
+  GENERATOR_IMAGE_NAME: decidim/decidim-generator
+  TEST_IMAGE_NAME: decidim/decidim-test
+  DEV_IMAGE_NAME: decidim/decidim-dev
+  APP_IMAGE_NAME: decidim/decidim
 
+jobs:
+  # ─── Prepare: fetch versions ───────────────────────────────────────
+  prepare:
+    runs-on: ubuntu-latest
+    outputs:
+      decidim_version: ${{ steps.decidim-version.outputs.version }}
+      ruby_version: ${{ steps.ruby-version.outputs.version }}
+      node_version: ${{ steps.node-version.outputs.version }}
     steps:
     - name: Fetch Decidim Tag
       id: decidim-tag
@@ -35,150 +38,590 @@ jobs:
       id: ruby-version
       env:
         RUBY_VERSION_URL: https://raw.githubusercontent.com/decidim/decidim/${{ steps.decidim-tag.outputs.tag }}/.ruby-version
-      run: |
-        echo "version=$(curl -s $RUBY_VERSION_URL)" >> $GITHUB_OUTPUT
+      run: echo "version=$(curl -s $RUBY_VERSION_URL)" >> $GITHUB_OUTPUT
 
     - name: Set Decidim Version
       id: decidim-version
-      run: echo ::set-output name=version::$(echo ${{ steps.decidim-tag.outputs.tag }} | cut -c2-)
+      run: echo "version=$(echo ${{ steps.decidim-tag.outputs.tag }} | cut -c2-)" >> $GITHUB_OUTPUT
 
     - name: Set Node Version
       id: node-version
       env:
         NODE_VERSION_URL: https://raw.githubusercontent.com/decidim/decidim/${{ steps.decidim-tag.outputs.tag }}/.node-version
-      run:
-        echo "version=$(curl -s $NODE_VERSION_URL | cut -d. -f1)" >> $GITHUB_OUTPUT
+      run: echo "version=$(curl -s $NODE_VERSION_URL | cut -d. -f1)" >> $GITHUB_OUTPUT
 
-    - name: Checkout Our Repo
-      uses: actions/checkout@v2
+  # ─── Build: decidim-generator (per-arch) ───────────────────────────
+  build-generator:
+    needs: prepare
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+        - linux/amd64
+        - linux/arm64
+    runs-on: ${{ contains(matrix.platform, 'arm64') && 'ubuntu-24.04-arm' || 'ubuntu-latest' }}
+    outputs:
+      image_name: ${{ env.GENERATOR_IMAGE_NAME }}
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
 
-    - name: Build decidim-generator Image
-      env:
-        RUBY_VERSION: ${{ steps.ruby-version.outputs.version }}
-        NODE_VERSION: ${{ steps.node-version.outputs.version }}
-        DECIDIM_VERSION: ${{ steps.decidim-version.outputs.version }}
-      run: |
-        docker build \
-        --build-arg ruby_version=$RUBY_VERSION \
-        --build-arg decidim_version=$DECIDIM_VERSION \
-        --build-arg node_version=$NODE_VERSION \
-        --file Dockerfile-generator \
-        -t $GENERATOR_IMAGE_NAME .
-        docker tag $GENERATOR_IMAGE_NAME $GENERATOR_IMAGE_NAME:$TAG
-        docker tag $GENERATOR_IMAGE_NAME ghcr.io/$GENERATOR_IMAGE_NAME:$TAG
-        docker tag $GENERATOR_IMAGE_NAME $GENERATOR_IMAGE_NAME:$DECIDIM_VERSION
-        docker tag $GENERATOR_IMAGE_NAME ghcr.io/$GENERATOR_IMAGE_NAME:$DECIDIM_VERSION
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
 
-    - name: Publish decidim-generator Image to Docker Hub
-      uses: docker/login-action@v1
+    - name: Log in to Docker Hub
+      uses: docker/login-action@v3
       with:
         username: decidimbot
         password: ${{ secrets.DOCKERHUB_PAT }}
-    - run: |
-        docker push --all-tags $GENERATOR_IMAGE_NAME
 
-    - name: Publish decidim-generator Image to GitHub Registry
-      uses: azure/docker-login@v1
+    - name: Log in to GitHub Container Registry
+      uses: docker/login-action@v3
       with:
-        login-server: ghcr.io
+        registry: ghcr.io
         username: decidim-bot
         password: ${{ secrets.CONTAINER_REGISTRY_PAT }}
-    - run: |
-        docker push --all-tags ghcr.io/$GENERATOR_IMAGE_NAME
 
-    - name: Build decidim-test Image
-      env:
-        RUBY_VERSION: ${{ steps.ruby-version.outputs.version }}
-        NODE_VERSION: ${{ steps.node-version.outputs.version }}
-        DECIDIM_VERSION: ${{ steps.decidim-version.outputs.version }}
+    - name: Docker meta
+      id: meta
+      uses: docker/metadata-action@v5
+      with:
+        images: |
+          ${{ env.GENERATOR_IMAGE_NAME }}
+          ghcr.io/${{ env.GENERATOR_IMAGE_NAME }}
+
+    - name: Build and push by digest (Docker Hub)
+      id: build-dockerhub
+      uses: docker/build-push-action@v6
+      with:
+        context: .
+        file: Dockerfile-generator
+        platforms: ${{ matrix.platform }}
+        build-args: |
+          ruby_version=${{ needs.prepare.outputs.ruby_version }}
+          decidim_version=${{ needs.prepare.outputs.decidim_version }}
+          node_version=${{ needs.prepare.outputs.node_version }}
+        labels: ${{ steps.meta.outputs.labels }}
+        cache-from: type=gha,scope=generator-${{ matrix.platform }}
+        cache-to: type=gha,scope=generator-${{ matrix.platform }},mode=max
+        outputs: type=image,name=${{ env.GENERATOR_IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
+
+    - name: Build and push by digest (GHCR)
+      id: build-ghcr
+      uses: docker/build-push-action@v6
+      with:
+        context: .
+        file: Dockerfile-generator
+        platforms: ${{ matrix.platform }}
+        build-args: |
+          ruby_version=${{ needs.prepare.outputs.ruby_version }}
+          decidim_version=${{ needs.prepare.outputs.decidim_version }}
+          node_version=${{ needs.prepare.outputs.node_version }}
+        labels: ${{ steps.meta.outputs.labels }}
+        cache-from: type=gha,scope=generator-${{ matrix.platform }}
+        outputs: type=image,name=ghcr.io/${{ env.GENERATOR_IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
+
+    - name: Export digests
       run: |
-        docker build \
-        --build-arg base_image=ghcr.io/$GENERATOR_IMAGE_NAME:$TAG \
-        --build-arg decidim_version=$DECIDIM_VERSION \
-        --build-arg node_version=$NODE_VERSION \
-        --file Dockerfile-test \
-        -t $TEST_IMAGE_NAME .
-        docker tag $TEST_IMAGE_NAME $TEST_IMAGE_NAME:$TAG
-        docker tag $TEST_IMAGE_NAME $TEST_IMAGE_NAME:$DECIDIM_VERSION
-        docker tag $TEST_IMAGE_NAME ghcr.io/$TEST_IMAGE_NAME:$TAG
-        docker tag $TEST_IMAGE_NAME ghcr.io/$TEST_IMAGE_NAME:$DECIDIM_VERSION
+        mkdir -p /tmp/digests/dockerhub /tmp/digests/ghcr
+        digest_dh="${{ steps.build-dockerhub.outputs.digest }}"
+        digest_ghcr="${{ steps.build-ghcr.outputs.digest }}"
+        touch "/tmp/digests/dockerhub/${digest_dh#sha256:}"
+        touch "/tmp/digests/ghcr/${digest_ghcr#sha256:}"
 
-    - name: Publish decidim-test Image to Docker Hub
-      uses: docker/login-action@v1
+    - name: Upload digest (Docker Hub)
+      uses: actions/upload-artifact@v4
+      with:
+        name: generator-digests-dockerhub-${{ contains(matrix.platform, 'arm64') && 'arm64' || 'amd64' }}
+        path: /tmp/digests/dockerhub/*
+        if-no-files-found: error
+        retention-days: 1
+
+    - name: Upload digest (GHCR)
+      uses: actions/upload-artifact@v4
+      with:
+        name: generator-digests-ghcr-${{ contains(matrix.platform, 'arm64') && 'arm64' || 'amd64' }}
+        path: /tmp/digests/ghcr/*
+        if-no-files-found: error
+        retention-days: 1
+
+  # ─── Merge: decidim-generator manifest ─────────────────────────────
+  merge-generator:
+    needs: [prepare, build-generator]
+    runs-on: ubuntu-latest
+    steps:
+    - name: Download Docker Hub digests
+      uses: actions/download-artifact@v4
+      with:
+        path: /tmp/digests/dockerhub
+        pattern: generator-digests-dockerhub-*
+        merge-multiple: true
+
+    - name: Download GHCR digests
+      uses: actions/download-artifact@v4
+      with:
+        path: /tmp/digests/ghcr
+        pattern: generator-digests-ghcr-*
+        merge-multiple: true
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Log in to Docker Hub
+      uses: docker/login-action@v3
       with:
         username: decidimbot
         password: ${{ secrets.DOCKERHUB_PAT }}
-    - run: |
-        docker push --all-tags $TEST_IMAGE_NAME
 
-    - name: Publish decidim-test Image to GitHub Registry
-      uses: azure/docker-login@v1
+    - name: Log in to GitHub Container Registry
+      uses: docker/login-action@v3
       with:
-        login-server: ghcr.io
+        registry: ghcr.io
         username: decidim-bot
         password: ${{ secrets.CONTAINER_REGISTRY_PAT }}
-    - run: |
-        docker push --all-tags ghcr.io/$TEST_IMAGE_NAME
 
-    - name: Build decidim-dev Image
-      env:
-        RUBY_VERSION: ${{ steps.ruby-version.outputs.version }}
-        NODE_VERSION: ${{ steps.node-version.outputs.version }}
-        DECIDIM_VERSION: ${{ steps.decidim-version.outputs.version }}
+    - name: Create manifest list (Docker Hub)
+      working-directory: /tmp/digests/dockerhub
       run: |
-        docker build \
-        --build-arg base_image=ghcr.io/$TEST_IMAGE_NAME:$TAG \
-        --file Dockerfile-dev \
-        -t $DEV_IMAGE_NAME .
-        docker tag $DEV_IMAGE_NAME $DEV_IMAGE_NAME:$TAG
-        docker tag $DEV_IMAGE_NAME $DEV_IMAGE_NAME:$DECIDIM_VERSION
-        docker tag $DEV_IMAGE_NAME ghcr.io/$DEV_IMAGE_NAME:$TAG
-        docker tag $DEV_IMAGE_NAME ghcr.io/$DEV_IMAGE_NAME:$DECIDIM_VERSION
+        TAGS="-t ${{ env.GENERATOR_IMAGE_NAME }}:latest \
+              -t ${{ env.GENERATOR_IMAGE_NAME }}:${{ needs.prepare.outputs.decidim_version }} \
+              -t ${{ env.GENERATOR_IMAGE_NAME }}:${{ github.sha }}"
+        docker buildx imagetools create $TAGS \
+          $(printf '${{ env.GENERATOR_IMAGE_NAME }}@sha256:%s ' *)
 
-    - name: Publish decidim-dev Image to Docker Hub
-      uses: docker/login-action@v1
+    - name: Create manifest list (GHCR)
+      working-directory: /tmp/digests/ghcr
+      run: |
+        TAGS="-t ghcr.io/${{ env.GENERATOR_IMAGE_NAME }}:latest \
+              -t ghcr.io/${{ env.GENERATOR_IMAGE_NAME }}:${{ needs.prepare.outputs.decidim_version }} \
+              -t ghcr.io/${{ env.GENERATOR_IMAGE_NAME }}:${{ github.sha }}"
+        docker buildx imagetools create $TAGS \
+          $(printf 'ghcr.io/${{ env.GENERATOR_IMAGE_NAME }}@sha256:%s ' *)
+
+  # ─── Build: decidim (app) (per-arch) ───────────────────────────────
+  build-app:
+    needs: [prepare, merge-generator]
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+        - linux/amd64
+        - linux/arm64
+    runs-on: ${{ contains(matrix.platform, 'arm64') && 'ubuntu-24.04-arm' || 'ubuntu-latest' }}
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Log in to Docker Hub
+      uses: docker/login-action@v3
       with:
         username: decidimbot
         password: ${{ secrets.DOCKERHUB_PAT }}
-    - run: |
-        docker push --all-tags $DEV_IMAGE_NAME
 
-    - name: Publish decidim-dev Image to GitHub Registry
-      uses: azure/docker-login@v1
+    - name: Log in to GitHub Container Registry
+      uses: docker/login-action@v3
       with:
-        login-server: ghcr.io
+        registry: ghcr.io
         username: decidim-bot
         password: ${{ secrets.CONTAINER_REGISTRY_PAT }}
-    - run: |
-        docker push --all-tags ghcr.io/$DEV_IMAGE_NAME
 
-    - name: Build decidim (app) Image
-      env:
-        RUBY_VERSION: ${{ steps.ruby-version.outputs.version }}
-        NODE_VERSION: ${{ steps.node-version.outputs.version }}
-        DECIDIM_VERSION: ${{ steps.decidim-version.outputs.version }}
+    - name: Docker meta
+      id: meta
+      uses: docker/metadata-action@v5
+      with:
+        images: |
+          ${{ env.APP_IMAGE_NAME }}
+          ghcr.io/${{ env.APP_IMAGE_NAME }}
+
+    - name: Build and push by digest (Docker Hub)
+      id: build-dockerhub
+      uses: docker/build-push-action@v6
+      with:
+        context: .
+        file: Dockerfile
+        platforms: ${{ matrix.platform }}
+        build-args: |
+          base_image=${{ env.GENERATOR_IMAGE_NAME }}:${{ github.sha }}
+        labels: ${{ steps.meta.outputs.labels }}
+        cache-from: type=gha,scope=app-${{ matrix.platform }}
+        cache-to: type=gha,scope=app-${{ matrix.platform }},mode=max
+        outputs: type=image,name=${{ env.APP_IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
+
+    - name: Build and push by digest (GHCR)
+      id: build-ghcr
+      uses: docker/build-push-action@v6
+      with:
+        context: .
+        file: Dockerfile
+        platforms: ${{ matrix.platform }}
+        build-args: |
+          base_image=ghcr.io/${{ env.GENERATOR_IMAGE_NAME }}:${{ github.sha }}
+        labels: ${{ steps.meta.outputs.labels }}
+        cache-from: type=gha,scope=app-${{ matrix.platform }}
+        outputs: type=image,name=ghcr.io/${{ env.APP_IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
+
+    - name: Export digests
       run: |
-        docker build \
-        --build-arg base_image=ghcr.io/$GENERATOR_IMAGE_NAME:$TAG \
-        -t $APP_IMAGE_NAME .
-        docker tag $APP_IMAGE_NAME $APP_IMAGE_NAME:$TAG
-        docker tag $APP_IMAGE_NAME $APP_IMAGE_NAME:$DECIDIM_VERSION
-        docker tag $APP_IMAGE_NAME ghcr.io/$APP_IMAGE_NAME:$TAG
-        docker tag $APP_IMAGE_NAME ghcr.io/$APP_IMAGE_NAME:$DECIDIM_VERSION
+        mkdir -p /tmp/digests/dockerhub /tmp/digests/ghcr
+        digest_dh="${{ steps.build-dockerhub.outputs.digest }}"
+        digest_ghcr="${{ steps.build-ghcr.outputs.digest }}"
+        touch "/tmp/digests/dockerhub/${digest_dh#sha256:}"
+        touch "/tmp/digests/ghcr/${digest_ghcr#sha256:}"
 
-    - name: Publish decidim Image to Docker Hub
-      uses: docker/login-action@v1
+    - name: Upload digest (Docker Hub)
+      uses: actions/upload-artifact@v4
+      with:
+        name: app-digests-dockerhub-${{ contains(matrix.platform, 'arm64') && 'arm64' || 'amd64' }}
+        path: /tmp/digests/dockerhub/*
+        if-no-files-found: error
+        retention-days: 1
+
+    - name: Upload digest (GHCR)
+      uses: actions/upload-artifact@v4
+      with:
+        name: app-digests-ghcr-${{ contains(matrix.platform, 'arm64') && 'arm64' || 'amd64' }}
+        path: /tmp/digests/ghcr/*
+        if-no-files-found: error
+        retention-days: 1
+
+  # ─── Merge: decidim (app) manifest ─────────────────────────────────
+  merge-app:
+    needs: [prepare, build-app]
+    runs-on: ubuntu-latest
+    steps:
+    - name: Download Docker Hub digests
+      uses: actions/download-artifact@v4
+      with:
+        path: /tmp/digests/dockerhub
+        pattern: app-digests-dockerhub-*
+        merge-multiple: true
+
+    - name: Download GHCR digests
+      uses: actions/download-artifact@v4
+      with:
+        path: /tmp/digests/ghcr
+        pattern: app-digests-ghcr-*
+        merge-multiple: true
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Log in to Docker Hub
+      uses: docker/login-action@v3
       with:
         username: decidimbot
         password: ${{ secrets.DOCKERHUB_PAT }}
-    - run: |
-        docker push --all-tags $APP_IMAGE_NAME
 
-    - name: Publish decidim Image to GitHub Registry
-      uses: azure/docker-login@v1
+    - name: Log in to GitHub Container Registry
+      uses: docker/login-action@v3
       with:
-        login-server: ghcr.io
+        registry: ghcr.io
         username: decidim-bot
         password: ${{ secrets.CONTAINER_REGISTRY_PAT }}
-    - run: |
-        docker push --all-tags ghcr.io/$APP_IMAGE_NAME
+
+    - name: Create manifest list (Docker Hub)
+      working-directory: /tmp/digests/dockerhub
+      run: |
+        TAGS="-t ${{ env.APP_IMAGE_NAME }}:latest \
+              -t ${{ env.APP_IMAGE_NAME }}:${{ needs.prepare.outputs.decidim_version }} \
+              -t ${{ env.APP_IMAGE_NAME }}:${{ github.sha }}"
+        docker buildx imagetools create $TAGS \
+          $(printf '${{ env.APP_IMAGE_NAME }}@sha256:%s ' *)
+
+    - name: Create manifest list (GHCR)
+      working-directory: /tmp/digests/ghcr
+      run: |
+        TAGS="-t ghcr.io/${{ env.APP_IMAGE_NAME }}:latest \
+              -t ghcr.io/${{ env.APP_IMAGE_NAME }}:${{ needs.prepare.outputs.decidim_version }} \
+              -t ghcr.io/${{ env.APP_IMAGE_NAME }}:${{ github.sha }}"
+        docker buildx imagetools create $TAGS \
+          $(printf 'ghcr.io/${{ env.APP_IMAGE_NAME }}@sha256:%s ' *)
+
+  # ─── Build: decidim-test (per-arch) ────────────────────────────────
+  build-test:
+    needs: [prepare, merge-generator]
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+        - linux/amd64
+        - linux/arm64
+    runs-on: ${{ contains(matrix.platform, 'arm64') && 'ubuntu-24.04-arm' || 'ubuntu-latest' }}
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Log in to Docker Hub
+      uses: docker/login-action@v3
+      with:
+        username: decidimbot
+        password: ${{ secrets.DOCKERHUB_PAT }}
+
+    - name: Log in to GitHub Container Registry
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: decidim-bot
+        password: ${{ secrets.CONTAINER_REGISTRY_PAT }}
+
+    - name: Docker meta
+      id: meta
+      uses: docker/metadata-action@v5
+      with:
+        images: |
+          ${{ env.TEST_IMAGE_NAME }}
+          ghcr.io/${{ env.TEST_IMAGE_NAME }}
+
+    - name: Build and push by digest (Docker Hub)
+      id: build-dockerhub
+      uses: docker/build-push-action@v6
+      with:
+        context: .
+        file: Dockerfile-test
+        platforms: ${{ matrix.platform }}
+        build-args: |
+          base_image=${{ env.GENERATOR_IMAGE_NAME }}:${{ github.sha }}
+          decidim_version=${{ needs.prepare.outputs.decidim_version }}
+        labels: ${{ steps.meta.outputs.labels }}
+        cache-from: type=gha,scope=test-${{ matrix.platform }}
+        cache-to: type=gha,scope=test-${{ matrix.platform }},mode=max
+        outputs: type=image,name=${{ env.TEST_IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
+
+    - name: Build and push by digest (GHCR)
+      id: build-ghcr
+      uses: docker/build-push-action@v6
+      with:
+        context: .
+        file: Dockerfile-test
+        platforms: ${{ matrix.platform }}
+        build-args: |
+          base_image=ghcr.io/${{ env.GENERATOR_IMAGE_NAME }}:${{ github.sha }}
+          decidim_version=${{ needs.prepare.outputs.decidim_version }}
+        labels: ${{ steps.meta.outputs.labels }}
+        cache-from: type=gha,scope=test-${{ matrix.platform }}
+        outputs: type=image,name=ghcr.io/${{ env.TEST_IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
+
+    - name: Export digests
+      run: |
+        mkdir -p /tmp/digests/dockerhub /tmp/digests/ghcr
+        digest_dh="${{ steps.build-dockerhub.outputs.digest }}"
+        digest_ghcr="${{ steps.build-ghcr.outputs.digest }}"
+        touch "/tmp/digests/dockerhub/${digest_dh#sha256:}"
+        touch "/tmp/digests/ghcr/${digest_ghcr#sha256:}"
+
+    - name: Upload digest (Docker Hub)
+      uses: actions/upload-artifact@v4
+      with:
+        name: test-digests-dockerhub-${{ contains(matrix.platform, 'arm64') && 'arm64' || 'amd64' }}
+        path: /tmp/digests/dockerhub/*
+        if-no-files-found: error
+        retention-days: 1
+
+    - name: Upload digest (GHCR)
+      uses: actions/upload-artifact@v4
+      with:
+        name: test-digests-ghcr-${{ contains(matrix.platform, 'arm64') && 'arm64' || 'amd64' }}
+        path: /tmp/digests/ghcr/*
+        if-no-files-found: error
+        retention-days: 1
+
+  # ─── Merge: decidim-test manifest ──────────────────────────────────
+  merge-test:
+    needs: [prepare, build-test]
+    runs-on: ubuntu-latest
+    steps:
+    - name: Download Docker Hub digests
+      uses: actions/download-artifact@v4
+      with:
+        path: /tmp/digests/dockerhub
+        pattern: test-digests-dockerhub-*
+        merge-multiple: true
+
+    - name: Download GHCR digests
+      uses: actions/download-artifact@v4
+      with:
+        path: /tmp/digests/ghcr
+        pattern: test-digests-ghcr-*
+        merge-multiple: true
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Log in to Docker Hub
+      uses: docker/login-action@v3
+      with:
+        username: decidimbot
+        password: ${{ secrets.DOCKERHUB_PAT }}
+
+    - name: Log in to GitHub Container Registry
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: decidim-bot
+        password: ${{ secrets.CONTAINER_REGISTRY_PAT }}
+
+    - name: Create manifest list (Docker Hub)
+      working-directory: /tmp/digests/dockerhub
+      run: |
+        TAGS="-t ${{ env.TEST_IMAGE_NAME }}:latest \
+              -t ${{ env.TEST_IMAGE_NAME }}:${{ needs.prepare.outputs.decidim_version }} \
+              -t ${{ env.TEST_IMAGE_NAME }}:${{ github.sha }}"
+        docker buildx imagetools create $TAGS \
+          $(printf '${{ env.TEST_IMAGE_NAME }}@sha256:%s ' *)
+
+    - name: Create manifest list (GHCR)
+      working-directory: /tmp/digests/ghcr
+      run: |
+        TAGS="-t ghcr.io/${{ env.TEST_IMAGE_NAME }}:latest \
+              -t ghcr.io/${{ env.TEST_IMAGE_NAME }}:${{ needs.prepare.outputs.decidim_version }} \
+              -t ghcr.io/${{ env.TEST_IMAGE_NAME }}:${{ github.sha }}"
+        docker buildx imagetools create $TAGS \
+          $(printf 'ghcr.io/${{ env.TEST_IMAGE_NAME }}@sha256:%s ' *)
+
+  # ─── Build: decidim-dev (per-arch) ─────────────────────────────────
+  build-dev:
+    needs: [prepare, merge-test]
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+        - linux/amd64
+        - linux/arm64
+    runs-on: ${{ contains(matrix.platform, 'arm64') && 'ubuntu-24.04-arm' || 'ubuntu-latest' }}
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Log in to Docker Hub
+      uses: docker/login-action@v3
+      with:
+        username: decidimbot
+        password: ${{ secrets.DOCKERHUB_PAT }}
+
+    - name: Log in to GitHub Container Registry
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: decidim-bot
+        password: ${{ secrets.CONTAINER_REGISTRY_PAT }}
+
+    - name: Docker meta
+      id: meta
+      uses: docker/metadata-action@v5
+      with:
+        images: |
+          ${{ env.DEV_IMAGE_NAME }}
+          ghcr.io/${{ env.DEV_IMAGE_NAME }}
+
+    - name: Build and push by digest (Docker Hub)
+      id: build-dockerhub
+      uses: docker/build-push-action@v6
+      with:
+        context: .
+        file: Dockerfile-dev
+        platforms: ${{ matrix.platform }}
+        build-args: |
+          base_image=${{ env.TEST_IMAGE_NAME }}:${{ github.sha }}
+        labels: ${{ steps.meta.outputs.labels }}
+        cache-from: type=gha,scope=dev-${{ matrix.platform }}
+        cache-to: type=gha,scope=dev-${{ matrix.platform }},mode=max
+        outputs: type=image,name=${{ env.DEV_IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
+
+    - name: Build and push by digest (GHCR)
+      id: build-ghcr
+      uses: docker/build-push-action@v6
+      with:
+        context: .
+        file: Dockerfile-dev
+        platforms: ${{ matrix.platform }}
+        build-args: |
+          base_image=ghcr.io/${{ env.TEST_IMAGE_NAME }}:${{ github.sha }}
+        labels: ${{ steps.meta.outputs.labels }}
+        cache-from: type=gha,scope=dev-${{ matrix.platform }}
+        outputs: type=image,name=ghcr.io/${{ env.DEV_IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
+
+    - name: Export digests
+      run: |
+        mkdir -p /tmp/digests/dockerhub /tmp/digests/ghcr
+        digest_dh="${{ steps.build-dockerhub.outputs.digest }}"
+        digest_ghcr="${{ steps.build-ghcr.outputs.digest }}"
+        touch "/tmp/digests/dockerhub/${digest_dh#sha256:}"
+        touch "/tmp/digests/ghcr/${digest_ghcr#sha256:}"
+
+    - name: Upload digest (Docker Hub)
+      uses: actions/upload-artifact@v4
+      with:
+        name: dev-digests-dockerhub-${{ contains(matrix.platform, 'arm64') && 'arm64' || 'amd64' }}
+        path: /tmp/digests/dockerhub/*
+        if-no-files-found: error
+        retention-days: 1
+
+    - name: Upload digest (GHCR)
+      uses: actions/upload-artifact@v4
+      with:
+        name: dev-digests-ghcr-${{ contains(matrix.platform, 'arm64') && 'arm64' || 'amd64' }}
+        path: /tmp/digests/ghcr/*
+        if-no-files-found: error
+        retention-days: 1
+
+  # ─── Merge: decidim-dev manifest ───────────────────────────────────
+  merge-dev:
+    needs: [prepare, build-dev]
+    runs-on: ubuntu-latest
+    steps:
+    - name: Download Docker Hub digests
+      uses: actions/download-artifact@v4
+      with:
+        path: /tmp/digests/dockerhub
+        pattern: dev-digests-dockerhub-*
+        merge-multiple: true
+
+    - name: Download GHCR digests
+      uses: actions/download-artifact@v4
+      with:
+        path: /tmp/digests/ghcr
+        pattern: dev-digests-ghcr-*
+        merge-multiple: true
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Log in to Docker Hub
+      uses: docker/login-action@v3
+      with:
+        username: decidimbot
+        password: ${{ secrets.DOCKERHUB_PAT }}
+
+    - name: Log in to GitHub Container Registry
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: decidim-bot
+        password: ${{ secrets.CONTAINER_REGISTRY_PAT }}
+
+    - name: Create manifest list (Docker Hub)
+      working-directory: /tmp/digests/dockerhub
+      run: |
+        TAGS="-t ${{ env.DEV_IMAGE_NAME }}:latest \
+              -t ${{ env.DEV_IMAGE_NAME }}:${{ needs.prepare.outputs.decidim_version }} \
+              -t ${{ env.DEV_IMAGE_NAME }}:${{ github.sha }}"
+        docker buildx imagetools create $TAGS \
+          $(printf '${{ env.DEV_IMAGE_NAME }}@sha256:%s ' *)
+
+    - name: Create manifest list (GHCR)
+      working-directory: /tmp/digests/ghcr
+      run: |
+        TAGS="-t ghcr.io/${{ env.DEV_IMAGE_NAME }}:latest \
+              -t ghcr.io/${{ env.DEV_IMAGE_NAME }}:${{ needs.prepare.outputs.decidim_version }} \
+              -t ghcr.io/${{ env.DEV_IMAGE_NAME }}:${{ github.sha }}"
+        docker buildx imagetools create $TAGS \
+          $(printf 'ghcr.io/${{ env.DEV_IMAGE_NAME }}@sha256:%s ' *)

--- a/Dockerfile-test
+++ b/Dockerfile-test
@@ -4,24 +4,34 @@ FROM $base_image
 LABEL maintainer="hola@decidim.org"
 
 ARG decidim_version=0.30.2
+ARG TARGETARCH
 
-RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
-  && sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list' \
-  && apt-get update \
-  && apt-get install -y google-chrome-stable \
-  && apt-get clean
+# Install Chrome + ChromeDriver (amd64) or Chromium + chromium-driver (arm64)
+RUN if [ "$TARGETARCH" = "arm64" ]; then \
+      apt-get update \
+      && apt-get install -y chromium chromium-driver \
+      && apt-get clean; \
+    else \
+      wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
+      && echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list \
+      && apt-get update \
+      && apt-get install -y google-chrome-stable \
+      && apt-get clean \
+      && apt-get install -y unzip curl \
+      && CHROME_VERSION=$(google-chrome --version | grep -oP '\d+\.\d+\.\d+\.\d+') \
+      && CHROMEDRIVER_URL="https://storage.googleapis.com/chrome-for-testing-public/${CHROME_VERSION}/linux64/chromedriver-linux64.zip" \
+      && curl -sL -o /tmp/chromedriver.zip "$CHROMEDRIVER_URL" \
+      && unzip -j /tmp/chromedriver.zip '*/chromedriver' -d /usr/local/bin \
+      && rm /tmp/chromedriver.zip \
+      && apt-get clean; \
+    fi
 
-RUN CHROMEDRIVER_RELEASE=85.0.4183.87 \
-  && CHROMEDRIVER_URL="http://chromedriver.storage.googleapis.com/$CHROMEDRIVER_RELEASE/chromedriver_linux64.zip" \
-  && apt-get install unzip \
-  && curl --silent --show-error --location --fail --retry 3 --output /tmp/chromedriver_linux64.zip $CHROMEDRIVER_URL \
-  && unzip /tmp/chromedriver_linux64.zip chromedriver -d /usr/local/bin \
-  && rm /tmp/chromedriver_linux64.zip
-
-RUN DOCKERIZE_VERSION=v0.6.1 \
-  && wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
-  && tar -C /usr/local/bin -xzvf dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
-  && rm dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz
+# Install dockerize (arch-aware, v0.8.0 for arm64 support)
+RUN DOCKERIZE_VERSION=v0.8.0 \
+    && DOCKERIZE_ARCH=$([ "$TARGETARCH" = "arm64" ] && echo "linux-arm64" || echo "linux-amd64") \
+    && wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-${DOCKERIZE_ARCH}-$DOCKERIZE_VERSION.tar.gz \
+    && tar -C /usr/local/bin -xzvf dockerize-${DOCKERIZE_ARCH}-$DOCKERIZE_VERSION.tar.gz \
+    && rm dockerize-${DOCKERIZE_ARCH}-$DOCKERIZE_VERSION.tar.gz
 
 RUN gem install decidim-dev:${decidim_version} --force
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,8 +3,8 @@ services:
   decidim:
     image: decidim/decidim:latest
     entrypoint: ["/code/vendor/hello-world.sh"]
-    # The entrypoint override above wipes out the CMD 
-    # on the Dockerfile-deploy, so we need to declare it 
+    # The entrypoint override above wipes out the CMD
+    # on the Dockerfile-deploy, so we need to declare it
     # again here (https://github.com/docker/compose/issues/3140)
     command: ["bundle", "exec", "rails", "s", "-b", "0.0.0.0"]
     ports:


### PR DESCRIPTION
## Summary

- Add `linux/arm64` support for all 4 Docker images (generator, app, test, dev), enabling native execution on Apple Silicon and ARM servers (AWS Graviton) without QEMU emulation
- Rewrite CI workflow to use Docker Buildx push-by-digest pattern with native ARM runners (`ubuntu-24.04-arm`)
- Make `Dockerfile-test` arch-aware: Google Chrome + ChromeDriver on amd64, Chromium + chromium-driver on arm64; bump dockerize to v0.8.0 for arm64 support

Closes #99

## Changes

### `Dockerfile-test`
- Use `TARGETARCH` build arg (auto-set by buildx) for conditional installs:
  - **amd64**: Google Chrome from Google's apt repo + matching ChromeDriver from Chrome for Testing
  - **arm64**: `chromium` + `chromium-driver` from Debian repos (Google Chrome has no arm64 Linux build)
- Bump dockerize from v0.6.1 to v0.8.0 (first version with arm64 binaries)

### `.github/workflows/dockerhub.yml`
- Replace monolithic single-job workflow with 9-job pipeline:
  - `prepare` fetches Decidim/Ruby/Node versions
  - `build-{image}` matrix [linux/amd64, linux/arm64] with native runners
  - `merge-{image}` combines per-arch digests into multi-arch manifests
- Dependency chain: generator then (app + test in parallel) then dev
- Push to both Docker Hub and GHCR (preserves existing behavior)
- Add GHA buildx layer cache to avoid rebuilding layers for dual-registry push
- Update all Actions to latest versions
- Fix deprecated set-output command
- Tags: latest, version, sha (unchanged)

### `docker-compose.yml`
- No functional changes (reverted to upstream state)

## Motivation

Issue #99 has been open since Dec 2022. On Apple Silicon Macs and ARM servers, the current amd64-only images run via slow QEMU emulation. Comparable projects (Discourse, Mastodon, GitLab, Chatwoot) all ship multi-arch images. This PR brings Decidim in line.

## Test plan

- [ ] Verify workflow YAML parses correctly
- [ ] CI builds both architectures for all 4 images
- [ ] After merge, verify multi-arch manifests
- [ ] Pull and run on Apple Silicon Mac without --platform flag
- [ ] Pull and run on amd64 machine with no behavior change

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added multi-architecture Docker image support, including ARM64 builds alongside x86_64.

* **Chores**
  * Refactored CI/CD pipeline for enhanced multi-platform Docker image building and publishing.
  * Updated architecture detection in Docker images for improved cross-platform compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->